### PR TITLE
Ensure chat models terminate generation with EOS token

### DIFF
--- a/src/lighteval/models/base_model.py
+++ b/src/lighteval/models/base_model.py
@@ -485,6 +485,7 @@ class BaseModel(LightevalModel):
             pad_token_id=self.tokenizer.pad_token_id if self.tokenizer.pad_token_id else self.tokenizer.eos_token_id,
             return_dict_in_generate=True,
             output_scores=True,
+            eos_token_id=self.tokenizer.eos_token_id,
         )
         if returns_logits:
             logits = self.model.compute_transition_scores(outputs.sequences, outputs.scores, normalize_logits=True)


### PR DESCRIPTION
Closes #109 

I'm not sure if there's any reason _not_ to specify the EOS token ID, but I have verified that adding this ensures chat models terminate on the EOS token.