### PR TITLE
Added support for launching inference endpoint with different model dtypes

### DIFF
--- a/src/lighteval/models/endpoint_model.py
+++ b/src/lighteval/models/endpoint_model.py
@@ -86,6 +86,7 @@ class InferenceEndpointModel(LightevalModel):
                             "MAX_INPUT_LENGTH": "2047",
                             "MAX_TOTAL_TOKENS": "2048",
                             "MODEL_ID": "/repository",
+                            **config.dtype_args
                         },
                         "url": "ghcr.io/huggingface/text-generation-inference:1.1.0",
                     },

--- a/src/lighteval/models/endpoint_model.py
+++ b/src/lighteval/models/endpoint_model.py
@@ -86,7 +86,7 @@ class InferenceEndpointModel(LightevalModel):
                             "MAX_INPUT_LENGTH": "2047",
                             "MAX_TOTAL_TOKENS": "2048",
                             "MODEL_ID": "/repository",
-                            **config.dtype_args
+                            **config.dtype_args,
                         },
                         "url": "ghcr.io/huggingface/text-generation-inference:1.1.0",
                     },

--- a/src/lighteval/models/model_config.py
+++ b/src/lighteval/models/model_config.py
@@ -283,7 +283,7 @@ def create_model_config(args: Namespace, accelerator: Union["Accelerator", None]
                 instance_size=args.instance_size,
                 instance_type=args.instance_type,
                 should_reuse_existing=args.reuse_existing,
-                dtype_args=get_endpoint_dtype_args(args.model_dtype)
+                dtype_args=get_endpoint_dtype_args(args.model_dtype),
             )
         return InferenceModelConfig(model=args.endpoint_model_name)
 
@@ -328,16 +328,16 @@ def create_model_config(args: Namespace, accelerator: Union["Accelerator", None]
         raise ValueError("You can't specifify a base model if you are not using delta/adapter weights")
     return BaseModelConfig(**args_dict)
 
+
 def get_endpoint_dtype_args(model_dtype: str):
     model_dtype = model_dtype.lower()
 
-    if model_dtype in ['awq', 'eetq', 'gptq']:
+    if model_dtype in ["awq", "eetq", "gptq"]:
         return dict(QUANTIZE=model_dtype)
-    if model_dtype == '8bit':
-        return dict(QUANTIZE='bitsandbytes')
-    if model_dtype == '4bit':
-        return dict(QUANTIZE='bitsandbytes-nf4')
-    if model_dtype in ['bfloat16', 'float16']:
+    if model_dtype == "8bit":
+        return dict(QUANTIZE="bitsandbytes")
+    if model_dtype == "4bit":
+        return dict(QUANTIZE="bitsandbytes-nf4")
+    if model_dtype in ["bfloat16", "float16"]:
         return dict(DTYPE=model_dtype)
     return None
-    


### PR DESCRIPTION
Following the documentation here: https://huggingface.co/docs/text-generation-inference/en/basic_tutorials/launcher#quantize

If the dtype specified doesn't match any of our conditions, we don't specify anything and let it fallback to the default.