### PR TITLE
Do not use deprecated list_files_info

### DIFF
--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -259,7 +259,7 @@ class EvaluationTracker:
 
         paths_to_check = [os.path.basename(results_file_path)]
         try:
-            checked_paths = list(self.api.list_files_info(repo_id=repo_id, paths=paths_to_check, repo_type="dataset"))
+            checked_paths = list(self.api.get_paths_info(repo_id=repo_id, paths=paths_to_check, repo_type="dataset"))
         except Exception:
             checked_paths = []
 


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/pull/2156.

`list_files_info` is deprecated in `huggingface_hub`'s package since release 0.19 and will be removed in next one (0.23). Better to use `get_paths_info` which works exactly the same in your use case :) 