### PR TITLE
fix: max_length type in  base_model.py

### DIFF
--- a/src/lighteval/models/base_model.py
+++ b/src/lighteval/models/base_model.py
@@ -259,7 +259,7 @@ class BaseModel(LightevalModel):
             int: Max length to use depending on the available args and config
         """
         if max_length is not None:
-            return max_length
+            return int(max_length)
         # Try to get the sequence length from the model config.
         seqlen_config_attrs = ("n_positions", "max_position_embeddings", "n_ctx")
 


### PR DESCRIPTION
if the max_length is passed from model_args, it gets parsed as str, and causes error for [the line](https://github.com/huggingface/transformers/blob/5ad7f17002f304b1e880fe2333c7deba95d12f4e/src/transformers/tokenization_utils_base.py#L3894)  `if max_length is None and len(ids) > self.model_max_length and verbose:`,  i.e. `TypeError: '>' not supported between instances of 'int' and 'str'`. This pr will fix the issue.