### PR TITLE
[MATH] Fix MATH normalization

### DIFF
--- a/src/lighteval/metrics/normalizations.py
+++ b/src/lighteval/metrics/normalizations.py
@@ -136,6 +136,24 @@ def math_normalizer(text: str, is_gold: bool = False) -> str:  # noqa C901
         return retval
 
     def _fix_fracs(text: str) -> str:
+        """
+        Fix the formatting of fractions in the given text.
+        Copied from: https://github.com/hendrycks/math/blob/357963a7f5501a6c1708cf3f3fb0cdf525642761/modeling/math_equivalence.py#L1
+
+        Args:
+            text (str): The input text.
+
+        Returns:
+            str: The text with properly formatted fractions.
+
+        Examples:
+            >>> _fix_fracs("\\frac12")
+            "\\frac{1}{2}"
+            >>> _fix_fracs("\\frac{3}{4}")
+            "\\frac{3}{4}"
+            >>> _fix_fracs("\\frac1{2}")
+            "\\frac{1}{2}"
+        """
         substrs = text.split("\\frac")
         new_str = substrs[0]
         if len(substrs) > 1:

--- a/src/lighteval/metrics/normalizations.py
+++ b/src/lighteval/metrics/normalizations.py
@@ -135,8 +135,8 @@ def math_normalizer(text: str, is_gold: bool = False) -> str:  # noqa C901
 
         return retval
 
-    def _fix_fracs(text: str) -> str:
-        substrs = text.split("\\frac")
+    def _fix_fracs(string):
+        substrs = string.split("\\frac")
         new_str = substrs[0]
         if len(substrs) > 1:
             substrs = substrs[1:]
@@ -147,9 +147,10 @@ def math_normalizer(text: str, is_gold: bool = False) -> str:  # noqa C901
                 else:
                     try:
                         assert len(substr) >= 2
-                    except AssertionError:
-                        return text
-                    a, b = substr
+                    except Exception:
+                        return string
+                    a = substr[0]
+                    b = substr[1]
                     if b != "{":
                         if len(substr) > 2:
                             post_substr = substr[2:]
@@ -162,8 +163,8 @@ def math_normalizer(text: str, is_gold: bool = False) -> str:  # noqa C901
                             new_str += "{" + a + "}" + b + post_substr
                         else:
                             new_str += "{" + a + "}" + b
-        text = new_str
-        return text
+        string = new_str
+        return string
 
     def _fix_a_slash_b(text: str) -> str:
         """Source: https://github.com/hendrycks/math

--- a/src/lighteval/metrics/normalizations.py
+++ b/src/lighteval/metrics/normalizations.py
@@ -147,7 +147,7 @@ def math_normalizer(text: str, is_gold: bool = False) -> str:  # noqa C901
                 else:
                     try:
                         assert len(substr) >= 2
-                    except Exception:
+                    except AssertionError:
                         return text
                     a = substr[0]
                     b = substr[1]

--- a/src/lighteval/metrics/normalizations.py
+++ b/src/lighteval/metrics/normalizations.py
@@ -135,8 +135,8 @@ def math_normalizer(text: str, is_gold: bool = False) -> str:  # noqa C901
 
         return retval
 
-    def _fix_fracs(string):
-        substrs = string.split("\\frac")
+    def _fix_fracs(text: str) -> str:
+        substrs = text.split("\\frac")
         new_str = substrs[0]
         if len(substrs) > 1:
             substrs = substrs[1:]
@@ -148,7 +148,7 @@ def math_normalizer(text: str, is_gold: bool = False) -> str:  # noqa C901
                     try:
                         assert len(substr) >= 2
                     except Exception:
-                        return string
+                        return text
                     a = substr[0]
                     b = substr[1]
                     if b != "{":
@@ -163,8 +163,8 @@ def math_normalizer(text: str, is_gold: bool = False) -> str:  # noqa C901
                             new_str += "{" + a + "}" + b + post_substr
                         else:
                             new_str += "{" + a + "}" + b
-        string = new_str
-        return string
+        text = new_str
+        return text
 
     def _fix_a_slash_b(text: str) -> str:
         """Source: https://github.com/hendrycks/math


### PR DESCRIPTION
Closes #140 by using the official `_fix_fracs()` function from the MATH [repo]( https://github.com/hendrycks/math/blob/357963a7f5501a6c1708cf3f3fb0cdf525642761/modeling/math_equivalence.py#L1).

Colab to test out the fix: https://colab.research.google.com/drive/1WumhmGpAoKbA-YaWwDB4gSSgKBZHF_i1?usp=sharing

Here's the code snippet that was triggering the error and now produces the correct output:

```python
s = "The fraction $\\frac{1}{2y+1}$ fails to be defined only if the denominator is zero. This occurs when $y$ is the solution of the equation $$2y+1=0,$$ which is $y=-\\frac 12$. Thus the domain of $k(y)$ is $$\\boxed{\\left(-\\infty,-\\frac 12\\right)\\cup \\left(-\\frac 12,\\infty\\right)}.$$"
math_normalizer(s, is_gold=True)
 # (-\infty,-\frac{1}{2})\cup(-\frac{1}{2},\infty) 
```

## TODO

- [ ] Run over some public models to validate scores look OK.