### PR TITLE
Fix prompt format german rag community task

### DIFF
--- a/community_tasks/german_rag_evals.py
+++ b/community_tasks/german_rag_evals.py
@@ -47,7 +47,7 @@ task1 = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split="test",
     few_shots_select="sequential",
-    metric=["loglikelihood_acc", "loglikelihood_acc_norm_nospace"],
+    metric=["loglikelihood_acc"],
 )
 
 # Task 2: Choose context by question.
@@ -63,7 +63,7 @@ task2 = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split="test",
     few_shots_select="sequential",
-    metric=["loglikelihood_acc", "loglikelihood_acc_norm_nospace"],
+    metric=["loglikelihood_acc"],
 )
 
 
@@ -80,7 +80,7 @@ task3 = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split="test",
     few_shots_select="sequential",
-    metric=["loglikelihood_acc", "loglikelihood_acc_norm_nospace"],
+    metric=["loglikelihood_acc"],
 )
 
 # Task 4: Context-question match.
@@ -96,7 +96,7 @@ task4 = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split="test",
     few_shots_select="sequential",
-    metric=["loglikelihood_acc", "loglikelihood_acc_norm_nospace"],
+    metric=["loglikelihood_acc"],
 )
 
 

--- a/community_tasks/german_rag_evals.py
+++ b/community_tasks/german_rag_evals.py
@@ -47,7 +47,7 @@ task1 = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split="test",
     few_shots_select="sequential",
-    metric=["loglikelihood_acc"],
+    metric=["loglikelihood_acc", "loglikelihood_acc_norm_nospace"],
 )
 
 # Task 2: Choose context by question.
@@ -63,7 +63,7 @@ task2 = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split="test",
     few_shots_select="sequential",
-    metric=["loglikelihood_acc"],
+    metric=["loglikelihood_acc", "loglikelihood_acc_norm_nospace"],
 )
 
 
@@ -80,7 +80,7 @@ task3 = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split="test",
     few_shots_select="sequential",
-    metric=["loglikelihood_acc"],
+    metric=["loglikelihood_acc", "loglikelihood_acc_norm_nospace"],
 )
 
 # Task 4: Context-question match.
@@ -96,7 +96,7 @@ task4 = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split="test",
     few_shots_select="sequential",
-    metric=["loglikelihood_acc"],
+    metric=["loglikelihood_acc", "loglikelihood_acc_norm_nospace"],
 )
 
 
@@ -110,7 +110,9 @@ Fragen:
 A: {choice_a}
 B: {choice_b}
 C: {choice_c}
-D: {choice_d}"""
+D: {choice_d}
+
+Antwort:"""
     query = instruction + query_template.format(
         context=line["context"],
         choice_a=line["choice_a"],
@@ -147,7 +149,9 @@ C:
 {choice_c}
 
 D:
-{choice_d}"""
+{choice_d}
+
+Antwort:"""
     query = instruction + query_template.format(
         question=line["question"],
         choice_a=line["choice_a"],
@@ -170,7 +174,9 @@ def prompt_fn_question_answer_match(line, task_name: str = None):
     query_template = """\
 Die Frage: {question}
 
-Die Antwort: {answer}"""
+Die Antwort: {answer}
+
+Auswahl (J/N):"""
     query = instruction + query_template.format(
         question=line["question"],
         answer=line["answer"],
@@ -191,7 +197,9 @@ def prompt_fn_context_question_match(line, task_name: str = None):
 Kontext:
 {context}
 
-Die Frage: {question}"""
+Die Frage: {question}
+
+Auswahl (J/N):"""
     query = instruction + query_template.format(
         question=line["question"],
         context=line["context"],


### PR DESCRIPTION
The prompts were ending after the answer options and accidentally missing the "Answer:" part (see e.g. [here](https://github.com/huggingface/lighteval/blob/11b48333b46ecd464cc3979de66038c87717e8d6/src/lighteval/tasks/tasks_prompt_formatting.py#L83)).

With this minor fix, the results are significantly different and closer to what´s expected, e.g. (ignore acc_norm), source for "old" results [here](https://huggingface.co/datasets/deutsche-telekom/Ger-RAG-eval):

## DiscoLM 7b German (original ChatML)

### New

```bash
|                         Task                         |Version| Metric |Value |   |Stderr|
|------------------------------------------------------|------:|--------|-----:|---|-----:|
|all                                                   |       |acc     |0.8737|±  |0.0094|
|                                                      |       |acc_norm|0.8737|±  |0.0094|
|community:german_rag_eval:_average:0                  |       |acc     |0.8737|±  |0.0094|
|                                                      |       |acc_norm|0.8737|±  |0.0094|
|community:german_rag_eval:choose_context_by_question:0|      0|acc     |0.7290|±  |0.0141|
|                                                      |       |acc_norm|0.7290|±  |0.0141|
|community:german_rag_eval:choose_question_by_context:0|      0|acc     |0.8490|±  |0.0113|
|                                                      |       |acc_norm|0.8490|±  |0.0113|
|community:german_rag_eval:context_question_match:0    |      0|acc     |0.9770|±  |0.0047|
|                                                      |       |acc_norm|0.9770|±  |0.0047|
|community:german_rag_eval:question_answer_match:0     |      0|acc     |0.9400|±  |0.0075|
|                                                      |       |acc_norm|0.9400|±  |0.0075|
```

### Old

```bash
|                         Task                         |Version|Metric|Value |   |Stderr|
|------------------------------------------------------|------:|------|-----:|---|-----:|
|all                                                   |       |acc   |0.7388|±  |0.0121|
|community:german_rag_eval:_average:0                  |       |acc   |0.7388|±  |0.0121|
|community:german_rag_eval:choose_context_by_question:0|      0|acc   |0.5940|±  |0.0155|
|community:german_rag_eval:choose_question_by_context:0|      0|acc   |0.9660|±  |0.0057|
|community:german_rag_eval:context_question_match:0    |      0|acc   |0.8430|±  |0.0115|
|community:german_rag_eval:question_answer_match:0     |      0|acc   |0.5520|±  |0.0157|
```

## Llama 3 8b Instruct

### New

```bash
|                         Task                         |Version| Metric |Value |   |Stderr|
|------------------------------------------------------|------:|--------|-----:|---|-----:|
|all                                                   |       |acc     |0.8633|±  |0.0089|
|                                                      |       |acc_norm|0.8633|±  |0.0089|
|community:german_rag_eval:_average:0                  |       |acc     |0.8633|±  |0.0089|
|                                                      |       |acc_norm|0.8633|±  |0.0089|
|community:german_rag_eval:choose_context_by_question:0|      0|acc     |0.6210|±  |0.0153|
|                                                      |       |acc_norm|0.6210|±  |0.0153|
|community:german_rag_eval:choose_question_by_context:0|      0|acc     |0.9910|±  |0.0030|
|                                                      |       |acc_norm|0.9910|±  |0.0030|
|community:german_rag_eval:context_question_match:0    |      0|acc     |0.9130|±  |0.0089|
|                                                      |       |acc_norm|0.9130|±  |0.0089|
|community:german_rag_eval:question_answer_match:0     |      0|acc     |0.9280|±  |0.0082|
|                                                      |       |acc_norm|0.9280|±  |0.0082|
```

### Old

```bash
|                         Task                         |Version|Metric|Value |   |Stderr|
|------------------------------------------------------|------:|------|-----:|---|-----:|
|all                                                   |       |acc   |0.7443|±  |0.0103|
|community:german_rag_eval:_average:0                  |       |acc   |0.7443|±  |0.0103|
|community:german_rag_eval:choose_context_by_question:0|      0|acc   |0.3230|±  |0.0148|
|community:german_rag_eval:choose_question_by_context:0|      0|acc   |0.7510|±  |0.0137|
|community:german_rag_eval:context_question_match:0    |      0|acc   |0.9810|±  |0.0043|
|community:german_rag_eval:question_answer_match:0     |      0|acc   |0.9220|±  |0.0085|
```

@PhilipMay 
