### PR TITLE
Mention HF_TOKEN in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The setup tested most is:
 pip install '.[accelerate,quantization,adapters]'
 ```
 
-If you want to push your results to the Hugging Face Hub, don't forget to add your access token to the environment variable `HUGGING_FACE_HUB_TOKEN`. You can do this by running:
+If you want to push your results to the Hugging Face Hub, don't forget to add your access token to the environment variable `HF_TOKEN`. You can do this by running:
 
 ```shell
 huggingface-cli login


### PR DESCRIPTION
Small README update to document `HF_TOKEN` instead of `HUGGING_FACE_HUB_TOKEN`. Goal is to make it consistent in the HF ecosystem. For the record, both are supported by `huggingface_hub` since quite some time but only [`HF_TOKEN`](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hftoken) is documented (and should be used).