### PR TITLE
Fix missing `LLM_AS_JUDGE` in `LightevalTask.construct_requests()`

### DIFF
--- a/src/lighteval/tasks/lighteval_task.py
+++ b/src/lighteval/tasks/lighteval_task.py
@@ -538,6 +538,18 @@ class LightevalTask:
                     generation_size=self.generation_size,
                 )
             ]
+        if self.has_metric_category[MetricCategory.LLM_AS_JUDGE]:
+            requests[RequestType.GREEDY_UNTIL] += [
+                GreedyUntilRequest(
+                    task_name=current_task_name,
+                    example_index=document_id_seed,
+                    request_index=0,
+                    context=context,
+                    stop_sequence=self.stop_sequence,
+                    generation_size=self.generation_size,
+                    num_samples=1,
+                )
+            ]
 
         return requests
 


### PR DESCRIPTION
Hi there!

To fix missing statement for `LLM_AS_JUDGE` in `LightevalTask.construct_requests()`
