### PR TITLE
Handle the naming of the (HF_)TOKEN variable

### DIFF
--- a/src/lighteval/main_accelerate.py
+++ b/src/lighteval/main_accelerate.py
@@ -42,7 +42,7 @@ from lighteval.utils_parallelism import test_all_gather
 if not is_accelerate_available() and not is_tgi_available():
     hlog_warn("Using either accelerate or text-generation to run this script is advised.")
 
-TOKEN = os.getenv("HF_TOKEN")
+TOKEN = os.gentenv("HF_TOKEN") if os.gentenv("HF_TOKEN") is not None else os.getenv("TOKEN")
 CACHE_DIR = os.getenv("HF_HOME")
 
 if is_accelerate_available():

--- a/src/lighteval/main_accelerate.py
+++ b/src/lighteval/main_accelerate.py
@@ -42,7 +42,7 @@ from lighteval.utils_parallelism import test_all_gather
 if not is_accelerate_available() and not is_tgi_available():
     hlog_warn("Using either accelerate or text-generation to run this script is advised.")
 
-TOKEN = os.gentenv("HF_TOKEN") if os.gentenv("HF_TOKEN") is not None else os.getenv("TOKEN")
+TOKEN = os.getenv("HF_TOKEN") if os.getenv("HF_TOKEN") is not None else os.getenv("TOKEN")
 CACHE_DIR = os.getenv("HF_HOME")
 
 if is_accelerate_available():


### PR DESCRIPTION
Demo leaderboard & backend had sometimes had TOKEN, sometimes HF_TOKEN as the relevant variable name. We standardized to TOKEN, but creating an inference endpoint via the demo leaderboard won't work because this lighteval code (which the demo leaderboard calls to) expects the variable to be named HF_TOKEN. Here I propose a solution that will adapt to the TOKEN name, but not break any other dependencies that assume HF_TOKEN.