### PR TITLE
Problems when loading a minimal free endpoints config. 

### DIFF
--- a/src/lighteval/models/model_config.py
+++ b/src/lighteval/models/model_config.py
@@ -323,10 +323,10 @@ def create_model_config(  # noqa: C901
         )
 
     if config["type"] == "endpoint":
-        reuse_existing_endpoint = config["base_params"]["reuse_existing"]
+        reuse_existing_endpoint = config["base_params"].get("reuse_existing", None)
         complete_config_endpoint = all(
             val not in [None, ""]
-            for key, val in config["instance"].items()
+            for key, val in config.get("instance", {}).items()
             if key not in InferenceEndpointModelConfig.nullable_keys()
         )
         if reuse_existing_endpoint or complete_config_endpoint:


### PR DESCRIPTION
`reuse_existing` and `instance` are params for the `inference-endpoint` models, not the `inference` ones.