### PR TITLE
Add tools to doc and to prompt

### DIFF
--- a/src/lighteval/models/base_model.py
+++ b/src/lighteval/models/base_model.py
@@ -567,7 +567,6 @@ class BaseModel(LightevalModel):
                     if max_new_tokens is None:  # If generation size is not set, we go all the way
                         max_new_tokens = self.max_length - context_size
                     else:
-                        print(self.max_length, context_size, max_new_tokens)
                         max_new_tokens = min(self.max_length - context_size, max_new_tokens)
                         if max_new_tokens < 1:
                             max_new_tokens = 1

--- a/src/lighteval/tasks/registry.py
+++ b/src/lighteval/tasks/registry.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from pprint import pformat
 from types import ModuleType
 from typing import Dict, List, Optional, Tuple, Union
+import warnings
 
 from datasets.load import dataset_module_factory
 
@@ -179,7 +180,10 @@ def create_custom_tasks_module(custom_tasks: Union[str, Path, ModuleType]) -> Mo
     if isinstance(custom_tasks, ModuleType):
         return custom_tasks
     if isinstance(custom_tasks, (str, Path)) and os.path.exists(custom_tasks):
-        dataset_module = dataset_module_factory(str(custom_tasks))
+        warnings.warn(
+            "Loading dataset with `trust_remote_code=True`. Make sure you trust the source of the dataset you are loading."
+        )
+        dataset_module = dataset_module_factory(str(custom_tasks), trust_remote_code=True)
         return importlib.import_module(dataset_module.module_path)
     if isinstance(custom_tasks, (str, Path)):
         return importlib.import_module(custom_tasks)

--- a/src/lighteval/tasks/requests.py
+++ b/src/lighteval/tasks/requests.py
@@ -189,6 +189,9 @@ class Doc:
     # The uncoditioned query shouldn't contain any information about the task, thus usually it's empty string or 'Answer:'.
     unconditioned_query: Optional[str] = None
 
+    # For tools
+    tools: Optional[list[dict]] = None
+
     def __post_init__(self):
         if self.instruction is None:
             self.instruction = ""


### PR DESCRIPTION
This PR adds the possibility of adding tools in the class `Doc` to be used in the `apply_chat_template` function. 

This PR is just a suggestion but it currently lacks any proper testing. 

### Example usage 

```py
def prompt_fn(sample, task_name: str = None):
  return Doc(
    task_name=task_name,
    query=sample["question"],
    choices=[sample["exact_tool"]],
    gold_index=0,
    instruction="",
    tools=sample["tools"],  # New 
  )
```