### PR TITLE
Math normalization: do not crash on invalid format

### DIFF
--- a/src/lighteval/metrics/normalizations.py
+++ b/src/lighteval/metrics/normalizations.py
@@ -103,15 +103,15 @@ def math_normalizer(text: str) -> str:  # noqa C901
                 left = "\\boxed "
                 assert text[: len(left)] == left
                 return text[len(left) :]
-    
+
             left = "\\boxed{"
-    
+
             assert text[: len(left)] == left
             assert text[-1] == "}"
-    
+
             return text[len(left) : -1]
         except Exception:
-            return None
+            return ""
 
     def _last_boxed_only_string(text: str) -> str | None:
         """Extract the last \\boxed{...} or \\fbox{...} element from a string."""

--- a/src/lighteval/metrics/normalizations.py
+++ b/src/lighteval/metrics/normalizations.py
@@ -98,17 +98,20 @@ def math_normalizer(text: str) -> str:  # noqa C901
         """
         if text is None:
             return ""
-        if "\\boxed " in text:
-            left = "\\boxed "
+        try:
+            if "\\boxed " in text:
+                left = "\\boxed "
+                assert text[: len(left)] == left
+                return text[len(left) :]
+    
+            left = "\\boxed{"
+    
             assert text[: len(left)] == left
-            return text[len(left) :]
-
-        left = "\\boxed{"
-
-        assert text[: len(left)] == left
-        assert text[-1] == "}"
-
-        return text[len(left) : -1]
+            assert text[-1] == "}"
+    
+            return text[len(left) : -1]
+        except Exception:
+            return None
 
     def _last_boxed_only_string(text: str) -> str | None:
         """Extract the last \\boxed{...} or \\fbox{...} element from a string."""


### PR DESCRIPTION
Wrap the asserts in a try except so that malformatted generations do not crash lighteval. See the original implem: https://github.com/hendrycks/math/blob/main/modeling/eval_math_gpt.py