### PR TITLE
Instructions for precommit hook for contributors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Got ideas? Found a bug? Want to add a
 Contributions are warmly
 welcomed!
 
+Install the precommit hook for styling tests when pushing to the codebase:
+```bash
+pip install .[dev]
+pre-commit install
+```
+
 ## 📜 Citation
 
 ```bibtex


### PR DESCRIPTION
Thank you for the new wiki! I am wondering if we could add instructions to install the precommit hook, this was one thing I originally overlooked in my initial setup which caused many PR fails 😅. This could also be added in the wiki's [task](https://github.com/huggingface/lighteval/wiki/Adding-a-Custom-Task) and [metric](https://github.com/huggingface/lighteval/wiki/Adding-a-New-Metric) sections, instead, so defer to your preference :). Thank you!