### PR TITLE
Fixes a TypeError in Sacrebleu.

### DIFF
--- a/src/lighteval/metrics/metrics_corpus.py
+++ b/src/lighteval/metrics/metrics_corpus.py
@@ -103,7 +103,7 @@ class CorpusLevelTranslationMetric:
     def compute(self, items: list[GenerativeCorpusMetricInput]) -> float:
         """Computes the metric score over all the corpus generated items, by using the sacrebleu implementation."""
         golds = [i.golds for i in items]
-        preds = [as_list(i.preds) for i in items]
+        preds = [pred for i in items for pred in i.preds]
         return float(self.metric(hypotheses=preds, references=golds).score)
 
 


### PR DESCRIPTION
SacreBleu expects the hypotheses to be a list of strings. We gave a list of list of strings which leads to a TypeError. I flattened the list to fix this.