### PR TITLE
Fix ignored reuse_existing in config file

### DIFF
--- a/src/lighteval/main_endpoint.py
+++ b/src/lighteval/main_endpoint.py
@@ -231,7 +231,7 @@ def inference_endpoint(
         "endpoint_name": config["base_params"].get("endpoint_name", None),
         "model_dtype": config["base_params"].get("dtype", None),
         "revision": config["base_params"].get("revision", None) or "main",
-        "should_reuse_existing": config["base_params"].get("should_reuse_existing"),
+        "reuse_existing": config["base_params"].get("reuse_existing"),
         "accelerator": config.get("instance", {}).get("accelerator", None),
         "region": config.get("instance", {}).get("region", None),
         "vendor": config.get("instance", {}).get("vendor", None),

--- a/src/lighteval/models/endpoints/endpoint_model.py
+++ b/src/lighteval/models/endpoints/endpoint_model.py
@@ -84,7 +84,7 @@ class InferenceModelConfig:
 class InferenceEndpointModelConfig:
     endpoint_name: str = None
     model_name: str = None
-    should_reuse_existing: bool = False
+    reuse_existing: bool = False
     accelerator: str = "gpu"
     model_dtype: str = None  # if empty, we use the default
     vendor: str = "aws"
@@ -135,7 +135,7 @@ class InferenceEndpointModel(LightevalModel):
     def __init__(  # noqa: C901
         self, config: Union[InferenceEndpointModelConfig, InferenceModelConfig], env_config: EnvConfig
     ) -> None:
-        self.reuse_existing = getattr(config, "should_reuse_existing", True)
+        self.reuse_existing = getattr(config, "reuse_existing", True)
         self._max_length = None
         self.endpoint = None
         self.model_name = None
@@ -171,7 +171,7 @@ class InferenceEndpointModel(LightevalModel):
             ):
                 try:
                     if self.endpoint is None:  # Endpoint does not exist yet locally
-                        if not config.should_reuse_existing:  # New endpoint
+                        if not config.reuse_existing:  # New endpoint
                             logger.info("Creating endpoint.")
                             self.endpoint: InferenceEndpoint = create_inference_endpoint(
                                 name=endpoint_name,
@@ -239,7 +239,7 @@ class InferenceEndpointModel(LightevalModel):
                     # The endpoint actually already exists, we'll spin it up instead of trying to create a new one
                     if "409 Client Error: Conflict for url:" in str(e):
                         config.endpoint_name = endpoint_name
-                        config.should_reuse_existing = True
+                        config.reuse_existing = True
                     # Requested resources are not available
                     elif "Bad Request: Compute instance not available yet" in str(e):
                         logger.error(

--- a/src/lighteval/models/endpoints/endpoint_model.py
+++ b/src/lighteval/models/endpoints/endpoint_model.py
@@ -135,7 +135,7 @@ class InferenceEndpointModel(LightevalModel):
     def __init__(  # noqa: C901
         self, config: Union[InferenceEndpointModelConfig, InferenceModelConfig], env_config: EnvConfig
     ) -> None:
-        self.reuse_existing = getattr(config, "reuse_existing", True)
+        self.reuse_existing = getattr(config, "reuse_existing", False)
         self._max_length = None
         self.endpoint = None
         self.model_name = None


### PR DESCRIPTION
Fix ignored `reuse_existing` field in config file.

Currently, there is a `reuse_existing` field in all example config files for evaluation in inference endpoints. See for example:
https://github.com/huggingface/lighteval/blob/9315f0d4d893050fce4e8b30839330052f4d15d5/examples/model_configs/endpoint_model.yaml#L6
or
https://github.com/huggingface/lighteval/blob/9315f0d4d893050fce4e8b30839330052f4d15d5/docs/source/evaluate-the-model-on-a-server-or-container.mdx?plain=1#L35

However, this field is ignored when parsing the config file because `should_reuse_existing` is parsed instead:
https://github.com/huggingface/lighteval/blob/9315f0d4d893050fce4e8b30839330052f4d15d5/src/lighteval/main_endpoint.py#L234

This PR fixes this issue by renaming `should_reuse_existing` to `reuse_existing`, so that it is aligned with the `InferenceEndpointModel` parameter name.