### PR TITLE
Update parameter typo in adding-a-custom-task.mdx

### DIFF
--- a/docs/source/adding-a-custom-task.mdx
+++ b/docs/source/adding-a-custom-task.mdx
@@ -184,5 +184,5 @@ Once your file is created you can then run the evaluation with the following com
 lighteval accelerate \
     "pretrained=HuggingFaceH4/zephyr-7b-beta" \
     "community|{custom_task}|{fewshots}|{truncate_few_shot}" \
-    --custom-tasks {path_to_your_custom_task_file}
+    --custom_tasks {path_to_your_custom_task_file}
 ```


### PR DESCRIPTION
This PR is for a small typo in the docs on parameters for the CLI.