### PR TITLE
Fix wrong instructions and code for custom tasks

### DIFF
--- a/community_tasks/_template.py
+++ b/community_tasks/_template.py
@@ -116,10 +116,3 @@ custom_metric = SampleLevelMetric(
     sample_level_fn=lambda x: x,  # how to compute score for one sample
     corpus_level_fn=np.mean,  # aggregation
 )
-
-# MODULE LOGIC
-# You should not need to touch this
-# Convert to dict for lighteval
-if __name__ == "__main__":
-    print(t.name for t in TASKS_TABLE)
-    print(len(TASKS_TABLE))

--- a/community_tasks/aimo_evals.py
+++ b/community_tasks/aimo_evals.py
@@ -56,11 +56,3 @@ task = LightevalTaskConfig(
 
 # STORE YOUR EVALS
 TASKS_TABLE = [task]
-
-
-# MODULE LOGIC
-# You should not need to touch this
-
-if __name__ == "__main__":
-    print(t.name for t in TASKS_TABLE)
-    print(len(TASKS_TABLE))

--- a/community_tasks/arabic_evals.py
+++ b/community_tasks/arabic_evals.py
@@ -856,7 +856,3 @@ TASKS_TABLE = (
     + [toxigen_ar_task]
     + [sciq_ar_task]
 )
-
-if __name__ == "__main__":
-    print(t.name for t in TASKS_TABLE)
-    print(len(TASKS_TABLE))

--- a/community_tasks/german_rag_evals.py
+++ b/community_tasks/german_rag_evals.py
@@ -221,11 +221,3 @@ task4 = LightevalTaskConfig(
 
 # STORE YOUR EVALS
 TASKS_TABLE = [task1, task2, task3, task4]
-
-
-# MODULE LOGIC
-# You should not need to touch this
-
-if __name__ == "__main__":
-    print(t.name for t in TASKS_TABLE)
-    print(len(TASKS_TABLE))

--- a/community_tasks/oz_evals.py
+++ b/community_tasks/oz_evals.py
@@ -87,8 +87,3 @@ oz_eval_task = LightevalTaskConfig(
 
 # STORE YOUR EVALS
 TASKS_TABLE = [oz_eval_task]
-
-
-if __name__ == "__main__":
-    print(t["name"] for t in TASKS_TABLE)
-    print(len(TASKS_TABLE))

--- a/community_tasks/serbian_eval.py
+++ b/community_tasks/serbian_eval.py
@@ -784,7 +784,3 @@ TASKS_TABLE = [
     mmlu_world_religions,
     mmlu_all,
 ]
-
-if __name__ == "__main__":
-    print(t.name for t in TASKS_TABLE)
-    print(len(TASKS_TABLE))

--- a/docs/source/adding-a-custom-task.mdx
+++ b/docs/source/adding-a-custom-task.mdx
@@ -167,17 +167,6 @@ TASKS_TABLE = SUBSET_TASKS
 # TASKS_TABLE = [task]
 ```
 
-Finally, you need to add a module logic to convert your task to a dict for lighteval.
-
-```python
-# MODULE LOGIC
-# You should not need to touch this
-# Convert to dict for lighteval
-if __name__ == "__main__":
-    print(t.name for t in TASKS_TABLE)
-    print(len(TASKS_TABLE))
-```
-
 Once your file is created you can then run the evaluation with the following command:
 
 ```bash

--- a/examples/nanotron/custom_evaluation_tasks.py
+++ b/examples/nanotron/custom_evaluation_tasks.py
@@ -671,7 +671,3 @@ TASKS_GROUPS = {
     "all": ",".join(t[1] for t in _TASKS_STRINGS),
     "early-signal": EARLY_SIGNAL_TASKS,
 }
-
-if __name__ == "__main__":
-    print(t["name"] for t in TASKS_TABLE)
-    print(len(TASKS_TABLE))

--- a/src/lighteval/tasks/extended/ifeval/main.py
+++ b/src/lighteval/tasks/extended/ifeval/main.py
@@ -160,8 +160,3 @@ ifeval = LightevalTaskConfig(
 TASKS_TABLE = [ifeval]
 
 extend_enum(Metrics, "ifeval_metric", ifeval_metrics)
-
-if __name__ == "__main__":
-    # Adds the metric to the metric list!
-    print(t["name"] for t in TASKS_TABLE)
-    print(len(TASKS_TABLE))

--- a/src/lighteval/tasks/extended/mix_eval/main.py
+++ b/src/lighteval/tasks/extended/mix_eval/main.py
@@ -228,8 +228,3 @@ mixeval_multichoice_hard = LightevalTaskConfig(
 
 
 TASKS_TABLE = [mixeval_multichoice_easy, mixeval_freeform_easy, mixeval_multichoice_hard, mixeval_freeform_hard]
-
-if __name__ == "__main__":
-    # Adds the metric to the metric list!
-    print(t["name"] for t in TASKS_TABLE)
-    print(len(TASKS_TABLE))

--- a/src/lighteval/tasks/extended/mt_bench/main.py
+++ b/src/lighteval/tasks/extended/mt_bench/main.py
@@ -95,7 +95,3 @@ task = LightevalTaskConfig(
 
 
 TASKS_TABLE = [task]
-
-if __name__ == "__main__":
-    print(t["name"] for t in TASKS_TABLE)
-    print(len(TASKS_TABLE))

--- a/src/lighteval/tasks/extended/tiny_benchmarks/main.py
+++ b/src/lighteval/tasks/extended/tiny_benchmarks/main.py
@@ -283,11 +283,3 @@ for task_param in task_params:
             corpus_level_fn=TinyCorpusAggregator(name).aggregate,
         ),
     )
-
-
-# MODULE LOGIC
-# You should not need to touch this
-# Convert to dict for lighteval
-if __name__ == "__main__":
-    print(t["name"] for t in TASKS_TABLE)
-    print(len(TASKS_TABLE))


### PR DESCRIPTION
Fix wrong instructions and code for custom tasks.

We are giving instructions to convert custom tasks to dict but this is not necessary or done (only prints are proposed):
```python
# Convert to dict for lighteval
if __name__ == "__main__":
    print(t.name for t in TASKS_TABLE)
    print(len(TASKS_TABLE))
```

In other parts of the code, we try to access attributes of Task instances as if it were a dict, which is wrong:
```python
print(t["name"] for t in TASKS_TABLE)
```
- should be `t.name` instead

This PR removes:
- the instructions to convert to dict
- the prints
