### PR TITLE
use concrete version instead of latest

### DIFF
--- a/src/lighteval/models/endpoints/endpoint_model.py
+++ b/src/lighteval/models/endpoints/endpoint_model.py
@@ -209,7 +209,7 @@ class InferenceEndpointModel(LightevalModel):
                                         **config.get_custom_env_vars(),
                                     },
                                     "url": (
-                                        config.image_url or "ghcr.io/huggingface/text-generation-inference:latest"
+                                        config.image_url or "ghcr.io/huggingface/text-generation-inference:3.0.1"
                                     ),
                                 },
                             )


### PR DESCRIPTION
Just noticed this while browsing the codebase. I'd recommend to use a concrete semver version when deploying TGI rather than latest.

If you e.g. look at the [packages](https://github.com/huggingface/text-generation-inference/pkgs/container/text-generation-inference), latest is now on sha-7eeefa3, so not something that's included in a release and might break.

Also, it makes debugging easier since you'll know exactly which version it is.

I used, 3.0.1 which is the latest release as of writing.