### PR TITLE
Support custom results/details push to hub

### DIFF
--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -318,13 +318,14 @@ class EvaluationTracker:
         repo_id = repo_id if "/" in repo_id else f"{self.hub_results_org}/{repo_id}"
         private = private if private is not None else not self.public
         self.api.create_repo(repo_id, private=private, repo_type="dataset", exist_ok=True)
-        details_json = "\n".join([json.dumps(detail) for detail in self.details])
-        self.api.upload_file(
-            repo_id=repo_id,
-            path_or_fileobj=details_json.encode(),
-            path_in_repo=path_in_repo,
-            repo_type="dataset",
-        )
+        for task_name, details in self.details:
+            details_json = "\n".join([json.dumps(detail) for detail in details])
+            self.api.upload_file(
+                repo_id=repo_id,
+                path_or_fileobj=details_json.encode(),
+                path_in_repo=path_in_repo.format(task_name=task_name),
+                repo_type="dataset",
+            )
 
     def recreate_metadata_card(self, repo_id: str) -> None:  # noqa: C901
         """Fully updates the details repository metadata card for the currently evaluated model


### PR DESCRIPTION
Support custom results/details push to hub.

This PR add 2 new methods (`push_results_to_hub` and `push_details_to_hub`) to allow the user to push results/details to the Hub in a completely customizable way (fully managed by the user).

The user can still call the old `push_to_hub` method to have it fully managed by the library.

TODO:
- [ ] Docstrings