### PR TITLE
Add EvaluationTracker to docs and fix its docstring

### DIFF
--- a/docs/source/package_reference/logging.mdx
+++ b/docs/source/package_reference/logging.mdx
@@ -1,4 +1,7 @@
-# Loggers
+# Logging
+
+## EvaluationTracker
+[[autodoc]] logging.evaluation_tracker.EvaluationTracker
 
 ## GeneralConfigLogger
 [[autodoc]] logging.info_loggers.GeneralConfigLogger

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -105,7 +105,7 @@ class EvaluationTracker:
         public (`bool`, defaults to False): If True, results and details are pushed to public orgs.
         nanotron_run_info ([`GeneralArgs`], *optional*): Reference to information about Nanotron models runs.
 
-    Attributes:
+    **Attributes**:
         details_logger ([`DetailsLogger`]): Logger for experiment details.
         metrics_logger ([`MetricsLogger`]): Logger for experiment metrics.
         versions_logger ([`VersionsLogger`]): Logger for task versions.

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -114,7 +114,7 @@ class EvaluationTracker:
             push_to_hub (bool): If True, details are pushed to the hub.
                 Results are pushed to `{hub_results_org}/details__{sanitized model_name}` for the model `model_name`, a public dataset,
                 if `public` is True else `{hub_results_org}/details__{sanitized model_name}_private`, a private dataset.
-            push_to_tensorboard (bool): If True, will create and push the results for a tensorboard folder on the hub
+            push_to_tensorboard (`bool`, defaults to False): If True, will create and push the results for a tensorboard folder on the hub.
             hub_results_org (str): The organisation to push the results to. See
                 more details about the datasets organisation in
                 [`EvaluationTracker.save`]

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -84,11 +84,11 @@ class EnhancedJSONEncoder(json.JSONEncoder):
 class EvaluationTracker:
     """Keeps track of the overall evaluation process and relevant information.
 
-    The [`EvaluationTracker`] contains specific loggers for experiments details
-    ([`DetailsLogger`]), metrics ([`MetricsLogger`]), task versions
-    ([`VersionsLogger`]) as well as for the general configurations of both the
-    specific task ([`TaskConfigLogger`]) and overall evaluation run
-    ([`GeneralConfigLogger`]).  It compiles the data from these loggers and
+    The [`~logging.evaluation_tracker.EvaluationTracker`] contains specific loggers for experiments details
+    ([`~logging.evaluation_tracker.DetailsLogger`]), metrics ([`~logging.evaluation_tracker.MetricsLogger`]), task versions
+    ([`~logging.evaluation_tracker.VersionsLogger`]) as well as for the general configurations of both the
+    specific task ([`~logging.evaluation_tracker.TaskConfigLogger`]) and overall evaluation run
+    ([`~logging.evaluation_tracker.GeneralConfigLogger`]).  It compiles the data from these loggers and
     writes it to files, which can be published to the Hugging Face hub if
     requested.
 
@@ -103,14 +103,14 @@ class EvaluationTracker:
             See more details about the datasets organisation in [`EvaluationTracker.save`].
         tensorboard_metric_prefix (`str`, defaults to "eval"): Prefix for the metrics in the tensorboard logs.
         public (`bool`, defaults to False): If True, results and details are pushed to public orgs.
-        nanotron_run_info ([`GeneralArgs`], *optional*): Reference to information about Nanotron models runs.
+        nanotron_run_info ([`~nanotron.config.GeneralArgs`], *optional*): Reference to information about Nanotron models runs.
 
     **Attributes**:
-        - **details_logger** ([`DetailsLogger`]) -- Logger for experiment details.
-        - **metrics_logger** ([`MetricsLogger`]) -- Logger for experiment metrics.
-        - **versions_logger** ([`VersionsLogger`]) -- Logger for task versions.
-        - **general_config_logger** ([`GeneralConfigLogger`]) -- Logger for general configuration.
-        - **task_config_logger** ([`TaskConfigLogger`]) -- Logger for task configuration.
+        - **details_logger** ([`~logging.info_loggers.DetailsLogger`]) -- Logger for experiment details.
+        - **metrics_logger** ([`~logging.info_loggers.MetricsLogger`]) -- Logger for experiment metrics.
+        - **versions_logger** ([`~logging.info_loggers.VersionsLogger`]) -- Logger for task versions.
+        - **general_config_logger** ([`~logging.info_loggers.GeneralConfigLogger`]) -- Logger for general configuration.
+        - **task_config_logger** ([`~logging.info_loggers.TaskConfigLogger`]) -- Logger for task configuration.
     """
 
     def __init__(

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -83,7 +83,7 @@ class EnhancedJSONEncoder(json.JSONEncoder):
 
 class EvaluationTracker:
     """
-    Keeps track of the overall evaluation process and relevant informations.
+    Keeps track of the overall evaluation process and relevant information.
 
     The [`EvaluationTracker`] contains specific loggers for experiments details
     ([`DetailsLogger`]), metrics ([`MetricsLogger`]), task versions
@@ -109,18 +109,17 @@ class EvaluationTracker:
         Creates all the necessary loggers for evaluation tracking.
 
         Args:
-            output_dir (str): Local folder path where you want results to be saved
-            save_details (bool): If True, details are saved to the output_dir
-            push_to_hub (bool): If True, details are pushed to the hub.
+            output_dir (`str`): Local folder path where you want results to be saved.
+            save_details (`bool`, defaults to True): If True, details are saved to the `output_dir`.
+            push_to_hub (`bool`, defaults to False): If True, details are pushed to the hub.
                 Results are pushed to `{hub_results_org}/details__{sanitized model_name}` for the model `model_name`, a public dataset,
                 if `public` is True else `{hub_results_org}/details__{sanitized model_name}_private`, a private dataset.
             push_to_tensorboard (`bool`, defaults to False): If True, will create and push the results for a tensorboard folder on the hub.
-            hub_results_org (str): The organisation to push the results to. See
-                more details about the datasets organisation in
-                [`EvaluationTracker.save`]
-            tensorboard_metric_prefix (str): Prefix for the metrics in the tensorboard logs
+            hub_results_org (`str`, *optional*): The organisation to push the results to.
+                See more details about the datasets organisation in [`EvaluationTracker.save`].
+            tensorboard_metric_prefix (`str`, defaults to "eval"): Prefix for the metrics in the tensorboard logs.
             public (`bool`, defaults to False): If True, results and details are pushed to public orgs.
-            nanotron_run_info (GeneralArgs): Reference to informations about Nanotron models runs
+            nanotron_run_info ([`GeneralArgs`], *optional*): Reference to information about Nanotron models runs.
         """
         self.details_logger = DetailsLogger()
         self.metrics_logger = MetricsLogger()

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -106,8 +106,8 @@ class EvaluationTracker:
         nanotron_run_info ([`GeneralArgs`], *optional*): Reference to information about Nanotron models runs.
 
     **Attributes**:
-        - **details_logger** ([`DetailsLogger`]) -- Logger for experiment details.
-        - **metrics_logger** ([`MetricsLogger`]): Logger for experiment metrics.
+    - **details_logger** ([`DetailsLogger`]) -- Logger for experiment details.
+    - **metrics_logger** ([`MetricsLogger`]) -- Logger for experiment metrics.
         - **versions_logger** ([`VersionsLogger`]): Logger for task versions.
         - **general_config_logger** ([`GeneralConfigLogger`]): Logger for general configuration.
         - **task_config_logger** ([`TaskConfigLogger`]): Logger for task configuration.

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -106,11 +106,11 @@ class EvaluationTracker:
         nanotron_run_info ([`GeneralArgs`], *optional*): Reference to information about Nanotron models runs.
 
     **Attributes**:
-        details_logger ([`DetailsLogger`]): Logger for experiment details.
-        metrics_logger ([`MetricsLogger`]): Logger for experiment metrics.
-        versions_logger ([`VersionsLogger`]): Logger for task versions.
-        general_config_logger ([`GeneralConfigLogger`]): Logger for general configuration.
-        task_config_logger ([`TaskConfigLogger`]): Logger for task configuration.
+        - details_logger ([`DetailsLogger`]): Logger for experiment details.
+        - metrics_logger ([`MetricsLogger`]): Logger for experiment metrics.
+        - versions_logger ([`VersionsLogger`]): Logger for task versions.
+        - general_config_logger ([`GeneralConfigLogger`]): Logger for general configuration.
+        - task_config_logger ([`TaskConfigLogger`]): Logger for task configuration.
     """
 
     def __init__(

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -106,11 +106,11 @@ class EvaluationTracker:
         nanotron_run_info ([`GeneralArgs`], *optional*): Reference to information about Nanotron models runs.
 
     **Attributes**:
-    - **details_logger** ([`DetailsLogger`]) -- Logger for experiment details.
-    - **metrics_logger** ([`MetricsLogger`]) -- Logger for experiment metrics.
-        - **versions_logger** ([`VersionsLogger`]): Logger for task versions.
-        - **general_config_logger** ([`GeneralConfigLogger`]): Logger for general configuration.
-        - **task_config_logger** ([`TaskConfigLogger`]): Logger for task configuration.
+        - **details_logger** ([`DetailsLogger`]) -- Logger for experiment details.
+        - **metrics_logger** ([`MetricsLogger`]) -- Logger for experiment metrics.
+        - **versions_logger** ([`VersionsLogger`]) -- Logger for task versions.
+        - **general_config_logger** ([`GeneralConfigLogger`]) -- Logger for general configuration.
+        - **task_config_logger** ([`TaskConfigLogger`]) -- Logger for task configuration.
     """
 
     def __init__(

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -106,7 +106,7 @@ class EvaluationTracker:
         nanotron_run_info ([`GeneralArgs`], *optional*): Reference to information about Nanotron models runs.
 
     **Attributes**:
-        - **details_logger** ([`DetailsLogger`]): Logger for experiment details.
+        - **details_logger** ([`DetailsLogger`]) -- Logger for experiment details.
         - **metrics_logger** ([`MetricsLogger`]): Logger for experiment metrics.
         - **versions_logger** ([`VersionsLogger`]): Logger for task versions.
         - **general_config_logger** ([`GeneralConfigLogger`]): Logger for general configuration.

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -106,11 +106,11 @@ class EvaluationTracker:
         nanotron_run_info ([`GeneralArgs`], *optional*): Reference to information about Nanotron models runs.
 
     **Attributes**:
-        - details_logger ([`DetailsLogger`]): Logger for experiment details.
-        - metrics_logger ([`MetricsLogger`]): Logger for experiment metrics.
-        - versions_logger ([`VersionsLogger`]): Logger for task versions.
-        - general_config_logger ([`GeneralConfigLogger`]): Logger for general configuration.
-        - task_config_logger ([`TaskConfigLogger`]): Logger for task configuration.
+        - **details_logger** ([`DetailsLogger`]): Logger for experiment details.
+        - **metrics_logger** ([`MetricsLogger`]): Logger for experiment metrics.
+        - **versions_logger** ([`VersionsLogger`]): Logger for task versions.
+        - **general_config_logger** ([`GeneralConfigLogger`]): Logger for general configuration.
+        - **task_config_logger** ([`TaskConfigLogger`]): Logger for task configuration.
     """
 
     def __init__(

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -82,8 +82,7 @@ class EnhancedJSONEncoder(json.JSONEncoder):
 
 
 class EvaluationTracker:
-    """
-    Keeps track of the overall evaluation process and relevant information.
+    """Keeps track of the overall evaluation process and relevant information.
 
     The [`EvaluationTracker`] contains specific loggers for experiments details
     ([`DetailsLogger`]), metrics ([`MetricsLogger`]), task versions
@@ -92,6 +91,19 @@ class EvaluationTracker:
     ([`GeneralConfigLogger`]).  It compiles the data from these loggers and
     writes it to files, which can be published to the Hugging Face hub if
     requested.
+
+    Args:
+        output_dir (`str`): Local folder path where you want results to be saved.
+        save_details (`bool`, defaults to True): If True, details are saved to the `output_dir`.
+        push_to_hub (`bool`, defaults to False): If True, details are pushed to the hub.
+            Results are pushed to `{hub_results_org}/details__{sanitized model_name}` for the model `model_name`, a public dataset,
+            if `public` is True else `{hub_results_org}/details__{sanitized model_name}_private`, a private dataset.
+        push_to_tensorboard (`bool`, defaults to False): If True, will create and push the results for a tensorboard folder on the hub.
+        hub_results_org (`str`, *optional*): The organisation to push the results to.
+            See more details about the datasets organisation in [`EvaluationTracker.save`].
+        tensorboard_metric_prefix (`str`, defaults to "eval"): Prefix for the metrics in the tensorboard logs.
+        public (`bool`, defaults to False): If True, results and details are pushed to public orgs.
+        nanotron_run_info ([`GeneralArgs`], *optional*): Reference to information about Nanotron models runs.
     """
 
     def __init__(
@@ -105,22 +117,7 @@ class EvaluationTracker:
         public: bool = False,
         nanotron_run_info: "GeneralArgs" = None,
     ) -> None:
-        """
-        Creates all the necessary loggers for evaluation tracking.
-
-        Args:
-            output_dir (`str`): Local folder path where you want results to be saved.
-            save_details (`bool`, defaults to True): If True, details are saved to the `output_dir`.
-            push_to_hub (`bool`, defaults to False): If True, details are pushed to the hub.
-                Results are pushed to `{hub_results_org}/details__{sanitized model_name}` for the model `model_name`, a public dataset,
-                if `public` is True else `{hub_results_org}/details__{sanitized model_name}_private`, a private dataset.
-            push_to_tensorboard (`bool`, defaults to False): If True, will create and push the results for a tensorboard folder on the hub.
-            hub_results_org (`str`, *optional*): The organisation to push the results to.
-                See more details about the datasets organisation in [`EvaluationTracker.save`].
-            tensorboard_metric_prefix (`str`, defaults to "eval"): Prefix for the metrics in the tensorboard logs.
-            public (`bool`, defaults to False): If True, results and details are pushed to public orgs.
-            nanotron_run_info ([`GeneralArgs`], *optional*): Reference to information about Nanotron models runs.
-        """
+        """Creates all the necessary loggers for evaluation tracking."""
         self.details_logger = DetailsLogger()
         self.metrics_logger = MetricsLogger()
         self.versions_logger = VersionsLogger()

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -114,7 +114,7 @@ class EvaluationTracker:
             push_to_hub (bool): If True, details are pushed to the hub.
                 Results are pushed to `{hub_results_org}/details__{sanitized model_name}` for the model `model_name`, a public dataset,
                 if `public` is True else `{hub_results_org}/details__{sanitized model_name}_private`, a private dataset.
-            push_results_to_tensorboard (bool): If True, will create and push the results for a tensorboard folder on the hub
+            push_to_tensorboard (bool): If True, will create and push the results for a tensorboard folder on the hub
             hub_results_org (str): The organisation to push the results to. See
                 more details about the datasets organisation in
                 [`EvaluationTracker.save`]

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -104,6 +104,13 @@ class EvaluationTracker:
         tensorboard_metric_prefix (`str`, defaults to "eval"): Prefix for the metrics in the tensorboard logs.
         public (`bool`, defaults to False): If True, results and details are pushed to public orgs.
         nanotron_run_info ([`GeneralArgs`], *optional*): Reference to information about Nanotron models runs.
+
+    Attributes:
+        details_logger ([`DetailsLogger`]): Logger for experiment details.
+        metrics_logger ([`MetricsLogger`]): Logger for experiment metrics.
+        versions_logger ([`VersionsLogger`]): Logger for task versions.
+        general_config_logger ([`GeneralConfigLogger`]): Logger for general configuration.
+        task_config_logger ([`TaskConfigLogger`]): Logger for task configuration.
     """
 
     def __init__(

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -119,7 +119,7 @@ class EvaluationTracker:
                 more details about the datasets organisation in
                 [`EvaluationTracker.save`]
             tensorboard_metric_prefix (str): Prefix for the metrics in the tensorboard logs
-            public (bool): If True, results and details are pushed in private orgs
+            public (`bool`, defaults to False): If True, results and details are pushed to public orgs.
             nanotron_run_info (GeneralArgs): Reference to informations about Nanotron models runs
         """
         self.details_logger = DetailsLogger()


### PR DESCRIPTION
Add `EvaluationTracker` to docs and fix its docstring:
- Fix `public` param definition
- Fix `push_to_tensorboard` param name
- Fix docstring style

See: https://moon-ci-docs.huggingface.co/docs/lighteval/pr_464/en/package_reference/logging#lighteval.logging.evaluation_tracker.EvaluationTracker