### PR TITLE
Fix warning about precedence of custom tasks over default ones in registry

### DIFF
--- a/src/lighteval/tasks/registry.py
+++ b/src/lighteval/tasks/registry.py
@@ -148,10 +148,10 @@ class Registry:
         intersection = set(default_tasks_registry.keys()).intersection(set(custom_tasks_registry.keys()))
         if len(intersection) > 0:
             logger.warning(
-                f"Following tasks ({intersection}) exists both in the default and custom tasks. Will use the default ones on conflict."
+                f"Following tasks ({intersection}) exists both in the default and custom tasks. Will use the custom ones on conflict."
             )
 
-        # Defaults tasks should overwrite custom tasks
+        # Custom tasks overwrite defaults tasks
         return {**default_tasks_registry, **custom_tasks_registry}
 
     @property

--- a/src/lighteval/tasks/registry.py
+++ b/src/lighteval/tasks/registry.py
@@ -152,7 +152,7 @@ class Registry:
             )
 
         # Defaults tasks should overwrite custom tasks
-        return {**custom_tasks_registry, **default_tasks_registry}
+        return {**default_tasks_registry, **custom_tasks_registry}
 
     @property
     @lru_cache

--- a/src/lighteval/tasks/registry.py
+++ b/src/lighteval/tasks/registry.py
@@ -152,7 +152,7 @@ class Registry:
             )
 
         # Defaults tasks should overwrite custom tasks
-        return {**default_tasks_registry, **custom_tasks_registry}
+        return {**custom_tasks_registry, **default_tasks_registry}
 
     @property
     @lru_cache


### PR DESCRIPTION
EDIT: See comment below: https://github.com/huggingface/lighteval/pull/466#issuecomment-2554794186

Fix warning about precedence of custom tasks over default ones in registry.

Currently, custom tasks are overwriting default ones, wheres the warning/comment says the opposite.

~~Fix precedence of default tasks over custom ones in registry.~~

~~Currently, custom tasks are overwriting default ones.~~