### PR TITLE
Checkout PR branches with a merge commit for CI tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,6 @@ jobs:
        uses: actions/checkout@v3
        with:
         lfs: 'true'
-        ref: ${{ github.event.pull_request.head.sha }} # we want to test against our branch not against a merge commit
      - name: Setup Python environment
        uses: actions/setup-python@v4
        with:


### PR DESCRIPTION
This PR runs the CI tests with a merge commit  of PR branches.

TODO:
- [x] Remove this requirement user-side
  - I have no access to the repo settings:
    - Settings > Branches > Branch protection rules > main > Edit
      - Require status checks to pass before merging:
        - Uncheck: Require branches to be up to date before merging 