### PR TITLE
Delete endpoint on InferenceEndpointTimeoutError

### DIFF
--- a/src/lighteval/models/endpoints/endpoint_model.py
+++ b/src/lighteval/models/endpoints/endpoint_model.py
@@ -257,6 +257,7 @@ class InferenceEndpointModel(LightevalModel):
                     logger.error(
                         "Endpoint did not start within 30 minutes, there was a timeout. Please inspect the logs."
                     )
+                    self.cleanup()
                     raise e
                 except HfHubHTTPError as e:
                     # The endpoint actually already exists, we'll spin it up instead of trying to create a new one


### PR DESCRIPTION
Delete endpoint on `InferenceEndpointTimeoutError`.

Currently, the user needs to delete it manually.