### PR TITLE
Fix `T_co` import bug

### DIFF
--- a/src/lighteval/data.py
+++ b/src/lighteval/data.py
@@ -26,7 +26,15 @@ from typing import Iterator, Tuple
 
 import torch
 from torch.utils.data import Dataset
-from torch.utils.data.distributed import DistributedSampler, T_co
+from packaging import version
+
+torch_version = torch.__version__
+
+if version.parse(torch_version) >= version.parse("2.5.0"):
+    from torch.utils.data.distributed import DistributedSampler, _T_co
+else:
+    from torch.utils.data.distributed import DistributedSampler
+    from torch.utils.data.distributed import T_co as _T_co
 
 from lighteval.tasks.requests import (
     GreedyUntilRequest,
@@ -318,7 +326,7 @@ class GenDistributedSampler(DistributedSampler):
     as our samples are sorted by length.
     """
 
-    def __iter__(self) -> Iterator[T_co]:
+    def __iter__(self) -> Iterator[_T_co]:
         if self.shuffle:
             # deterministically shuffle based on epoch and seed
             g = torch.Generator()


### PR DESCRIPTION
# What does this PR do?
This PR fixes a bug (`ImportError`) when trying to import `T_co` with `torch==2.5.0` or newer. It appears that the variable `T_co` has been renamed to `_T_co` in `torch`. Please see https://github.com/pytorch/pytorch/blob/ee1b6804381c57161c477caa380a840a84167676/torch/utils/data/distributed.py#L10 and https://github.com/pytorch/pytorch/blob/a1ae8fadc709f7c18788f8828ee3166f96245bec/torch/utils/data/distributed.py#L13
