### PR TITLE
Fixed issue with o1 in litellm.

### DIFF
--- a/src/lighteval/models/litellm_model.py
+++ b/src/lighteval/models/litellm_model.py
@@ -91,7 +91,7 @@ class LiteLLMClient(LightevalModel):
         self._tokenizer = encode
         self.pairwise_tokenization = False
         litellm.drop_params = True
-        litellm.verbose = True
+        litellm.set_verbose = False
 
     def _prepare_stop_sequence(self, stop_sequence):
         """Prepare and validate stop sequence."""
@@ -130,13 +130,16 @@ class LiteLLMClient(LightevalModel):
                     "messages": prompt,
                     "max_completion_tokens": max_new_tokens,
                     "logprobs": return_logits if self.provider == "openai" else None,
-                    "stop": stop_sequence,
                     "base_url": self.base_url,
                     "n": num_samples,
-                    "temperature": self.TEMPERATURE,
-                    "top_p": self.TOP_P,
                     "caching": True,
                 }
+                if "o1" in self.model:
+                    logger.warning("O1 models do not support temperature, top_p, stop sequence. Disabling.")
+                else:
+                    kwargs["temperature"] = self.TEMPERATURE
+                    kwargs["top_p"] = self.TOP_P
+                    kwargs["stop"] = stop_sequence
 
                 response = litellm.completion(**kwargs)
 


### PR DESCRIPTION
The o1 models throw an error if you feed them with the temperature, top_p or stop sequences.