### PR TITLE
Fixed bug of import url_to_fs from fsspec (#507)

### DIFF
--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -34,7 +34,7 @@ from pathlib import Path
 import torch
 from datasets import Dataset, load_dataset
 from datasets.utils.metadata import MetadataConfigs
-from fsspec import url_to_fs
+from fsspec.core import url_to_fs
 from huggingface_hub import DatasetCard, DatasetCardData, HfApi, HFSummaryWriter, hf_hub_url
 
 from lighteval.logging.info_loggers import (

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -34,7 +34,10 @@ from pathlib import Path
 import torch
 from datasets import Dataset, load_dataset
 from datasets.utils.metadata import MetadataConfigs
-from fsspec.core import url_to_fs
+try:
+    from fsspec import url_to_fs
+except ImportError:
+    from fsspec.core import url_to_fs
 from huggingface_hub import DatasetCard, DatasetCardData, HfApi, HFSummaryWriter, hf_hub_url
 
 from lighteval.logging.info_loggers import (

--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -34,10 +34,6 @@ from pathlib import Path
 import torch
 from datasets import Dataset, load_dataset
 from datasets.utils.metadata import MetadataConfigs
-try:
-    from fsspec import url_to_fs
-except ImportError:
-    from fsspec.core import url_to_fs
 from huggingface_hub import DatasetCard, DatasetCardData, HfApi, HFSummaryWriter, hf_hub_url
 
 from lighteval.logging.info_loggers import (
@@ -55,6 +51,11 @@ logger = logging.getLogger(__name__)
 
 if is_nanotron_available():
     from nanotron.config import GeneralArgs  # type: ignore
+
+try:
+    from fsspec import url_to_fs
+except ImportError:
+    from fsspec.core import url_to_fs
 
 
 class EnhancedJSONEncoder(json.JSONEncoder):


### PR DESCRIPTION
Fixed #507 
Update to import `url_to_fs` from `fsspec.core`.

```python
from fsspec.core import url_to_fs
```

**It should now work.**

```
[2025-01-24 12:57:59,214] [    INFO]: PyTorch version 2.4.1+cpu available. (config.py:54)
[2025-01-24 12:58:23,232] [    INFO]: Test gather tensor (parallelism.py:133)
[2025-01-24 12:58:23,234] [    INFO]: gathered_tensor tensor([0]), should be [0] (parallelism.py:136)
[2025-01-24 12:58:23,234] [    INFO]: --- LOADING MODEL --- (pipeline.py:168)
[2025-01-24 12:58:24,585] [    INFO]: Tokenizer truncation and padding size set to the left side. (transformers_model.py:539)
[2025-01-24 12:58:24,586] [    INFO]: We are not in a distributed setting. Setting model_parallel to False. (transformers_model.py:394)
[2025-01-24 12:58:24,586] [    INFO]: Model parallel was set to False, max memory set to None and device map to None (transformers_model.py:423) 
[2025-01-24 12:58:26,047] [    INFO]: Using Data Parallelism, putting model on device cpu (transformers_model.py:275)
[2025-01-24 12:58:26,352] [    INFO]: --- LOADING TASKS --- (pipeline.py:195)
```