### PR TITLE
Fix Ukrainian indices and confirmation word

### DIFF
--- a/src/lighteval/tasks/templates/utils/translation_literals.py
+++ b/src/lighteval/tasks/templates/utils/translation_literals.py
@@ -980,7 +980,7 @@ TRANSLATION_LITERALS: dict[Language, TranslationLiterals] = {
         language=Language.UKRAINIAN,
         question_word="питання",
         answer="відповідь",
-        confirmation_word="вірно",
+        confirmation_word="правильно",
         yes="так",
         no="ні",
         also="також",
@@ -998,6 +998,7 @@ TRANSLATION_LITERALS: dict[Language, TranslationLiterals] = {
         sentence_space=" ",
         colon=":",
         semicolon=";",
+        indices=["А", "Б", "В", "Г", "Д", "Е"],
     ),
     Language.URDU: TranslationLiterals(
         language=Language.URDU,


### PR DESCRIPTION
Changes for Ukrainian:
* Fixed ambiguity for `confirmation_word`: changed `"вірно"` to `"правильно"` - updated word is a standard one used for tests and exams, while the original version is a bit more ambiguous. Technically both translation are correct for `right` in English.
* Added `indices`: `["А", "Б", "В", "Г", "Д", "Е"]` though the fifth letter in Ukrainian letter is `Ґ`, it is not used for tests or national exams.