### PR TITLE
Add custom task (bac-fr) for evaluation of models in french

### DIFF
--- a/community_tasks/french_evals.py
+++ b/community_tasks/french_evals.py
@@ -82,14 +82,24 @@ def prompt_gpqa_fr(line, task_name: str = None):
 
 # BAC-fr prompt function
 def prompt_bac_fr(line, task_name: str = None):
-    return Doc(
-        task_name=task_name,
-        query=line["prompt"],
-        choices=[""],
-        gold_index=0,
-        instruction="",
-        specific={"instruction": line["instruction"], "enonce": line["enonce"]},
-    )
+    prompt = f"Enoncé: {line['enonce"]}\n{line['instruction'}\n"
+    if line["Choix"] is not None: # Multichoice evaluation
+        prompt += "\n".join([f"{LETTER_INDICES[ix]}.{choix}" for ix, choix in enumerate(line["choix"])])
+        return Doc(
+            task_name = task_name,
+            query = prompt,
+            choices = aslist(line["Choix"])
+            gold_index = line["Choix"].index(line["Choix correct"])
+            instruction = ""
+        )
+  else:
+          return Doc(
+            task_name = task_name,
+            query = prompt,
+            choices = [line["reponse"]]
+            gold_index = 0
+            instruction = ""
+        )
 
 
 # IFEVal-fr task

--- a/community_tasks/french_evals.py
+++ b/community_tasks/french_evals.py
@@ -80,6 +80,18 @@ def prompt_gpqa_fr(line, task_name: str = None):
     )
 
 
+# BAC-fr prompt function
+def prompt_bac_fr(line, task_name: str = None):
+    return Doc(
+        task_name=task_name,
+        query=line["prompt"],
+        choices=[""],
+        gold_index=0,
+        instruction="",
+        specific={"instruction": line["instruction"], "enonce": line["enonce"]},
+    )
+
+
 # IFEVal-fr task
 
 
@@ -117,5 +129,23 @@ gpqa_fr_task = LightevalTaskConfig(
     version=0,
 )
 
+# BAC-fr task
+bac_fr_task = LightevalTaskConfig(
+    name="bac-fr",
+    suite=["community"],
+    prompt_function=prompt_bac_fr,
+    hf_repo="fr-gouv-coordination-ia/bac-fr",
+    hf_subset="default",
+    hf_avail_splits=["train"],
+    evaluation_splits=["train"],
+    few_shots_split=None,
+    few_shots_select="random_sampling",
+    generation_size=1,
+    metric=[],  # To be defined
+    stop_sequence=["\n"],
+    trust_dataset=True,
+    version=0,
+)
+
 # STORE YOUR EVALS
-TASKS_TABLE = [ifeval_fr_task, gpqa_fr_task]
+TASKS_TABLE = [ifeval_fr_task, gpqa_fr_task, bac_fr_task]

--- a/community_tasks/french_evals.py
+++ b/community_tasks/french_evals.py
@@ -46,6 +46,7 @@ from lighteval.tasks.default_prompts import LETTER_INDICES
 from lighteval.tasks.extended.ifeval.main import ifeval_metrics
 from lighteval.tasks.lighteval_task import LightevalTaskConfig
 from lighteval.tasks.requests import Doc
+from lighteval.utils.utils import as_list
 
 
 # Ifeval-fr prompt function
@@ -88,7 +89,7 @@ def prompt_bac_fr(line, task_name: str = None):
         return Doc(
             task_name=task_name,
             query=prompt,
-            choices=list(line["Choix"]),
+            choices=as_list(line["Choix"]),
             gold_index=line["Choix"].index(line["Choix correct"]),
             instruction="",
         )

--- a/community_tasks/french_evals.py
+++ b/community_tasks/french_evals.py
@@ -84,13 +84,13 @@ def prompt_gpqa_fr(line, task_name: str = None):
 # BAC-fr prompt function
 def prompt_bac_fr(line, task_name: str = None):
     prompt = f"Enoncé: {line['enonce']}\n{line['instruction']}\n"
-    if line["Choix"] is not None:  # Multichoice evaluation
-        prompt += "\n".join([f"{LETTER_INDICES[ix]}.{choix}" for ix, choix in enumerate(line["choix"])])
+    if line["choix"] is not None:  # Multichoice evaluation
+        # prompt += "\n".join([f"{LETTER_INDICES[ix]}.{choix}" for ix, choix in enumerate(line["choix"])])
         return Doc(
             task_name=task_name,
             query=prompt,
-            choices=as_list(line["Choix"]),
-            gold_index=line["Choix"].index(line["Choix correct"]),
+            choices=as_list(line["choix"]),
+            gold_index=line["choix"].index(line["choix correct"]),
             instruction="",
         )
     else:

--- a/community_tasks/french_evals.py
+++ b/community_tasks/french_evals.py
@@ -82,24 +82,18 @@ def prompt_gpqa_fr(line, task_name: str = None):
 
 # BAC-fr prompt function
 def prompt_bac_fr(line, task_name: str = None):
-    prompt = f"Enoncé: {line['enonce"]}\n{line['instruction'}\n"
-    if line["Choix"] is not None: # Multichoice evaluation
+    prompt = f"Enoncé: {line['enonce']}\n{line['instruction']}\n"
+    if line["Choix"] is not None:  # Multichoice evaluation
         prompt += "\n".join([f"{LETTER_INDICES[ix]}.{choix}" for ix, choix in enumerate(line["choix"])])
         return Doc(
-            task_name = task_name,
-            query = prompt,
-            choices = aslist(line["Choix"])
-            gold_index = line["Choix"].index(line["Choix correct"])
-            instruction = ""
+            task_name=task_name,
+            query=prompt,
+            choices=list(line["Choix"]),
+            gold_index=line["Choix"].index(line["Choix correct"]),
+            instruction="",
         )
-  else:
-          return Doc(
-            task_name = task_name,
-            query = prompt,
-            choices = [line["reponse"]]
-            gold_index = 0
-            instruction = ""
-        )
+    else:
+        return Doc(task_name=task_name, query=prompt, choices=[line["reponse"]], gold_index=0, instruction="")
 
 
 # IFEVal-fr task
@@ -151,7 +145,7 @@ bac_fr_task = LightevalTaskConfig(
     few_shots_split=None,
     few_shots_select="random_sampling",
     generation_size=1,
-    metric=[],  # To be defined
+    metric=[Metrics.quasi_exact_match_math, Metrics.exact_match],
     stop_sequence=["\n"],
     trust_dataset=True,
     version=0,


### PR DESCRIPTION
Propose a specific task to run on the bac-fr, a dataset composed of questions extracted from the french BAC exam.
The header of the dataset is like this:

| Instruction | Question | Réponse | Réponse étendue | Choix | Choix correct | Matière | Année | Sujet |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
|  |  |  |  |  |  |  |  |  |

We need to clearly define the metrics that will be used, as well as how the prompt will formulate its requests (@clefourrier).
