### PR TITLE
Adding verbal-reasoning-challenge as a Community Task

### DIFF
--- a/community_tasks/verbal_reasoning_challenge.py
+++ b/community_tasks/verbal_reasoning_challenge.py
@@ -71,14 +71,8 @@ def _parse_answer(text: str) -> List[List[str]]:
 
 
 def _answer_without_thoughts(completion: str) -> str:
-    if "<think>" not in completion[:200]:
-        return completion
-
-    chunks = completion.split("</think>")
-    if len(chunks) <= 1:
-        return ""
-
-    return chunks[-1].strip()
+    completion = re.sub(r"(<think>)?[^<]*<\/think>", "", completion).strip()
+    return completion
 
 
 def _check_answer(completion: str, answer: str) -> bool:


### PR DESCRIPTION
I am hoping to contribute verbal-reasoning-challenege as a new community tasks. Authored with @arjunguha

The Verbal Reasoning Challenge is a dataset designed to evaluate the reasoning abilities of Large Language Models. It is based on the "off-air challenges" from the NPR Sunday Puzzle Challenge, which are designed to be understandable by any adult in the United States. 

Link to the paper: https://arxiv.org/abs/2502.01584
Link to the dataset: https://huggingface.co/datasets/nuprl/verbal-reasoning-challenge