### PR TITLE
Fix vLLM max tokens

### DIFF
--- a/src/lighteval/models/vllm/vllm_model.py
+++ b/src/lighteval/models/vllm/vllm_model.py
@@ -317,8 +317,8 @@ class VLLMModel(LightevalModel):
         if generate:
             sampling_params.n = num_samples
             sampling_params.max_tokens = (
-                max_new_tokens if sampling_params.max_tokens is None else sampling_params.max_tokens
-            )
+                max_new_tokens if max_new_tokens is not None else sampling_params.max_tokens
+            )  # vLLM's sampling_params.max_tokens is 16 by default
             sampling_params.stop = stop_tokens
             sampling_params.logprobs = 1 if returns_logits else 0
 


### PR DESCRIPTION
vLLM has  `max_tokens`  as Optional[int] but defaulting to 16 [here](https://github.com/vllm-project/vllm/blob/d84cef76eb9e16190cfdd97ae24511c8c819f179/vllm/sampling_params.py#L186)
That means whenever sampling_params is created, it assumes the value 16 and hence this sampling_params.max_tokens ends up being always equal to 16
Then the lighteval benchmark goes on to warn that the output is not in the Gold Format ...

