### PR TITLE
Fix vLLM generation with sampling params

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ tensorboardX = ["tensorboardX"]
 vllm = ["vllm>=0.7.0", "ray", "more_itertools"]
 quality = ["ruff==v0.2.2","pre-commit"]
 tests = ["pytest==7.4.0"]
-dev = ["lighteval[accelerate,quality,tests,multilingual,math]"]
+dev = ["lighteval[accelerate,quality,tests,multilingual,math,extended_tasks]"]
 docs = ["hf-doc-builder", "watchdog"]
 extended_tasks = [
   "langdetect", # ifeval

--- a/src/lighteval/main_vllm.py
+++ b/src/lighteval/main_vllm.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import os
+import re
 from typing import Optional
 
 from typer import Argument, Option
@@ -138,6 +139,8 @@ def vllm(
         generation_parameters = GenerationParameters.from_dict(config)
     else:
         generation_parameters = GenerationParameters.from_model_args(model_args)
+        # We slice out generation_parameters from model_args to avoid double-counting in the VLLMModelConfig
+        model_args = re.sub(r"generation_parameters=\{.*?\},?", "", model_args).strip(",")
         metric_options = {}
 
     model_args_dict: dict = {k.split("=")[0]: k.split("=")[1] if "=" in k else True for k in model_args.split(",")}

--- a/src/lighteval/main_vllm.py
+++ b/src/lighteval/main_vllm.py
@@ -144,6 +144,9 @@ def vllm(
         metric_options = {}
 
     model_args_dict: dict = {k.split("=")[0]: k.split("=")[1] if "=" in k else True for k in model_args.split(",")}
+
+    print(f"{model_args_dict=}")
+    print(f"{generation_parameters=}")
     model_config = VLLMModelConfig(**model_args_dict, generation_parameters=generation_parameters)
 
     pipeline = Pipeline(

--- a/src/lighteval/main_vllm.py
+++ b/src/lighteval/main_vllm.py
@@ -144,9 +144,6 @@ def vllm(
         metric_options = {}
 
     model_args_dict: dict = {k.split("=")[0]: k.split("=")[1] if "=" in k else True for k in model_args.split(",")}
-
-    print(f"{model_args_dict=}")
-    print(f"{generation_parameters=}")
     model_config = VLLMModelConfig(**model_args_dict, generation_parameters=generation_parameters)
 
     pipeline = Pipeline(

--- a/src/lighteval/models/sglang/sglang_model.py
+++ b/src/lighteval/models/sglang/sglang_model.py
@@ -216,14 +216,14 @@ class SGLangModel(LightevalModel):
             if max_new_tokens is not None:
                 if context_size + max_new_tokens > self.max_length:
                     logger.warning(
-                        f"{context_size + max_new_tokens=} which is greather than {self.max_length=}. Truncating context to {self.max_length - max_new_tokens} tokens."
+                        f"{context_size + max_new_tokens=} which is greater than {self.max_length=}. Truncating context to {self.max_length - max_new_tokens} tokens."
                     )
                     context_size = self.max_length - max_new_tokens
                     inputs = [input[-context_size:] for input in inputs]
             else:
                 if context_size > self.max_length:
                     logger.warning(
-                        f"{context_size=} which is greather than {self.max_length=}. Truncating context to {self.max_length} tokens."
+                        f"{context_size=} which is greater than {self.max_length=}. Truncating context to {self.max_length} tokens."
                     )
                     context_size = self.max_length
                     inputs = [input[-context_size:] for input in inputs]

--- a/src/lighteval/models/vllm/vllm_model.py
+++ b/src/lighteval/models/vllm/vllm_model.py
@@ -318,6 +318,7 @@ class VLLMModel(LightevalModel):
         generate: bool = True,
     ) -> list[GenerativeResponse]:
         """Contains the actual logic of the generation."""
+        print(f"{self.sampling_params.clone()=}")
         sampling_params = self.sampling_params.clone() or SamplingParams()
         if generate:
             sampling_params.n = num_samples
@@ -343,6 +344,7 @@ class VLLMModel(LightevalModel):
             # as VLLM complains about no GPUs available.
             @ray.remote(num_gpus=1 if self.tensor_parallel_size == 1 else None)
             def run_inference_one_model(model_args: dict, sampling_params: SamplingParams, requests):
+                print(f"Sampling params: {sampling_params}")
                 llm = LLM(**model_args)
                 return llm.generate(prompt_token_ids=requests, sampling_params=sampling_params)
 

--- a/src/lighteval/models/vllm/vllm_model.py
+++ b/src/lighteval/models/vllm/vllm_model.py
@@ -318,7 +318,6 @@ class VLLMModel(LightevalModel):
         generate: bool = True,
     ) -> list[GenerativeResponse]:
         """Contains the actual logic of the generation."""
-        print(f"{self.sampling_params.clone()=}")
         sampling_params = self.sampling_params.clone() or SamplingParams()
         if generate:
             sampling_params.n = num_samples
@@ -344,7 +343,6 @@ class VLLMModel(LightevalModel):
             # as VLLM complains about no GPUs available.
             @ray.remote(num_gpus=1 if self.tensor_parallel_size == 1 else None)
             def run_inference_one_model(model_args: dict, sampling_params: SamplingParams, requests):
-                print(f"Sampling params: {sampling_params}")
                 llm = LLM(**model_args)
                 return llm.generate(prompt_token_ids=requests, sampling_params=sampling_params)
 

--- a/src/lighteval/models/vllm/vllm_model.py
+++ b/src/lighteval/models/vllm/vllm_model.py
@@ -266,7 +266,7 @@ class VLLMModel(LightevalModel):
             if max_new_tokens is not None:
                 if context_size + max_new_tokens > self.max_length:
                     logger.warning(
-                        f"{context_size + max_new_tokens=} which is greather than {self.max_length=}. Truncating context to {self.max_length - max_new_tokens} tokens."
+                        f"{context_size + max_new_tokens=} which is greater than {self.max_length=}. Truncating context to {self.max_length - max_new_tokens} tokens."
                     )
                     context_size = self.max_length - max_new_tokens
                     if context_size < 0:
@@ -278,7 +278,7 @@ class VLLMModel(LightevalModel):
             else:
                 if context_size > self.max_length:
                     logger.warning(
-                        f"{context_size=} which is greather than {self.max_length=}. Truncating context to {self.max_length} tokens."
+                        f"{context_size=} which is greater than {self.max_length=}. Truncating context to {self.max_length} tokens."
                     )
                     context_size = self.max_length
                     inputs = [input[-context_size:] for input in inputs]

--- a/src/lighteval/tasks/extended/lcb/main.py
+++ b/src/lighteval/tasks/extended/lcb/main.py
@@ -21,9 +21,8 @@
 # SOFTWARE.
 """Usage:
 lighteval vllm \
-    "pretrained=deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B,dtype=float16,tensor_parallel_size=4,max_model_length=32768,gpu_memory_utilisation=0.8" \
-    "extended|lcb:codegeneration|0|0" \
-    --custom-tasks src/lighteval/tasks/extended/lcb/main.py
+    "pretrained=deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B,data_parallel_size=8,max_model_length=32768,gpu_memory_utilization=0.8,generation_parameters={temperature: 0.6,top_p: 0.95}" \
+    "extended|lcb:codegeneration|0|0"
 """
 
 import json

--- a/src/lighteval/tasks/extended/lcb/main.py
+++ b/src/lighteval/tasks/extended/lcb/main.py
@@ -21,7 +21,11 @@
 # SOFTWARE.
 """Usage:
 lighteval vllm \
-    "pretrained=deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B,data_parallel_size=8,max_model_length=32768,gpu_memory_utilization=0.8,generation_parameters={temperature: 0.6,top_p: 0.95}" \
+    "pretrained=deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B,dtype=bfloat16,data_parallel_size=8,max_model_length=32768,gpu_memory_utilization=0.8,generation_parameters={temperature:0.6,top_p:0.95}" \
+    "extended|lcb:codegeneration|0|0"
+
+lighteval vllm \
+    "pretrained=Qwen/Qwen2.5-Coder-3B-Instruct,dtype=bfloat16,data_parallel_size=8,max_model_length=32768,gpu_memory_utilization=0.8,generation_parameters={temperature:0.2,top_p:0.95}" \
     "extended|lcb:codegeneration|0|0"
 """
 


### PR DESCRIPTION
This PR fixes a bug where it was not possible to pass `generation_parameters` to `lighteval vllm` due to:

```
TypeError: lighteval.models.vllm.vllm_model.VLLMModelConfig() got multiple values for keyword argument 'generation_parameters'
```

The root cause was due to `model_args` containing `generation_parameters` after we extracted them.