### PR TITLE
Add Turkish and word

### DIFF
--- a/src/lighteval/tasks/templates/utils/translation_literals.py
+++ b/src/lighteval/tasks/templates/utils/translation_literals.py
@@ -950,6 +950,7 @@ TRANSLATION_LITERALS: dict[Language, TranslationLiterals] = {
         false="yanlış",
         neither="hiçbiri",
         or_word="veya",
+        and_word="ve",
         full_stop=".",
         comma=",",
         question_mark="?",


### PR DESCRIPTION
Hey everyone, I hit a bump while trying to evaluate the MATH-500 benchmark on a model derived from Hugging Face’s Open-R1 repository. The process tripped up because the code was looking for an "and_word" that just wasn’t there. This tiny pull request sorts that out by making sure the "and_word" is added.