### PR TITLE
Add subsets for lcb

### DIFF
--- a/src/lighteval/tasks/extended/lcb/main.py
+++ b/src/lighteval/tasks/extended/lcb/main.py
@@ -115,7 +115,7 @@ lcb_codegen_metric = SampleLevelMetric(
 
 extend_enum(Metrics, "lcb_codegen_metric", lcb_codegen_metric)
 
-configs = get_dataset_config_names("livecodebench/code_generation_lite")
+configs = get_dataset_config_names("livecodebench/code_generation_lite", trust_remote_code=True)
 
 tasks = []
 


### PR DESCRIPTION
## Description

Adds subsets to `lcb`:

The previous subset `v4_v5` keeps with the same name to avoid confusion, but now 2 more subsets are included:

```shell
MODEL_ARGS=...
lighteval vllm \
    $MODEL_ARGS \
    "extended|lcb:codegeneration_v4|0|0" \
    --use-chat-template
```

and 

```shell
lighteval vllm \
    $MODEL_ARGS \
    "extended|lcb:codegeneration_v5|0|0" \
    --use-chat-template
```

@edbeeching, @lewtun, @NathanHB 