### PR TITLE
Parse string values for add_special_tokens in vLLM

### DIFF
--- a/src/lighteval/models/vllm/vllm_model.py
+++ b/src/lighteval/models/vllm/vllm_model.py
@@ -114,7 +114,8 @@ class VLLMModel(LightevalModel):
         self.tensor_parallel_size = int(config.tensor_parallel_size)
 
         self._add_special_tokens = (
-            config.add_special_tokens if isinstance(config.add_special_tokens, bool)
+            config.add_special_tokens
+            if isinstance(config.add_special_tokens, bool)
             else str(config.add_special_tokens).lower() == "true"
         )
         self._tokenizer = self._create_auto_tokenizer(config, env_config)

--- a/src/lighteval/models/vllm/vllm_model.py
+++ b/src/lighteval/models/vllm/vllm_model.py
@@ -113,7 +113,10 @@ class VLLMModel(LightevalModel):
         self.data_parallel_size = int(config.data_parallel_size)
         self.tensor_parallel_size = int(config.tensor_parallel_size)
 
-        self._add_special_tokens = config.add_special_tokens if config.add_special_tokens is not None else False
+        self._add_special_tokens = (
+            config.add_special_tokens if isinstance(config.add_special_tokens, bool)
+            else str(config.add_special_tokens).lower() == "true"
+        )
         self._tokenizer = self._create_auto_tokenizer(config, env_config)
 
         self._max_length = int(config.max_model_length) if config.max_model_length is not None else None


### PR DESCRIPTION
When trying to evaluate reasoning models on e.g. AIME task, we would run evals like this:
```bash
MODEL=deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
MODEL_ARGS="pretrained=$MODEL,dtype=bfloat16,max_model_length=32768,gpu_memory_utilization=0.8,generation_parameters={max_new_tokens:32768,temperature:0.6,top_p:0.95}"
OUTPUT_DIR=data/evals/$MODEL

# AIME 2024
TASK=aime24
lighteval vllm $MODEL_ARGS "custom|$TASK|0|0" \
    --custom-tasks src/open_r1/evaluate.py \
    --use-chat-template \
    --output-dir $OUTPUT_DIR
```

As part of `MODEL_ARGS` we would like to be able to specify value for `add_special_tokens` to control whether BOS token is added or not by tokenizer. At the moment this is not possible because the given value will be interpreted as string whereas the codebase relies on boolean. This PR enables this by parsing `add_special_tokens` like other vLLM params are parsed in the `class VLLMModel`.