### PR TITLE
Add --use-chat-template to the broken litellm example

### DIFF
--- a/docs/source/use-litellm-as-backend.mdx
+++ b/docs/source/use-litellm-as-backend.mdx
@@ -77,5 +77,6 @@ And then, we are able to eval our model on any eval available in Lighteval.
 ```bash
 lighteval endpoint litellm \
     "examples/model_configs/litellm_model.yaml" \
-    "lighteval|gsm8k|0|0"
+    "lighteval|gsm8k|0|0" \
+    --use-chat-template
 ```


### PR DESCRIPTION
The existing example in docs is broken. According to https://github.com/huggingface/lighteval/issues/565 , litellm models should have `--use-chat-template`.