### PR TITLE
Add CLI arg `generate_until_token` to support reasoning and CoT models

### DIFF
--- a/src/lighteval/main_accelerate.py
+++ b/src/lighteval/main_accelerate.py
@@ -70,6 +70,9 @@ def accelerate(  # noqa C901
     load_responses_from_details_date_id: Annotated[
         Optional[str], Option(help="Load responses from details directory.", rich_help_panel=HELP_PANEL_NAME_1)
     ] = None,
+    generate_until_token: Annotated[
+        Optional[str], Option(help="Continue generating reasoning or chain-of-thought after system prompt and until this stop token.", rich_help_panel=HELP_PANEL_NAME_4)
+    ] = None,
     # === saving ===
     output_dir: Annotated[
         str, Option(help="Output directory for evaluation results.", rich_help_panel=HELP_PANEL_NAME_2)
@@ -121,6 +124,9 @@ def accelerate(  # noqa C901
 
     env_config = EnvConfig(token=TOKEN, cache_dir=cache_dir)
 
+    if (not use_chat_template) and (generate_until_token is not None):
+        raise Exception("`generate_until_token` must be used with `use_chat_template` flag.")
+
     evaluation_tracker = EvaluationTracker(
         output_dir=output_dir,
         save_details=save_details,
@@ -141,6 +147,7 @@ def accelerate(  # noqa C901
         use_chat_template=use_chat_template,
         system_prompt=system_prompt,
         load_responses_from_details_date_id=load_responses_from_details_date_id,
+        generate_until_token=generate_until_token,
     )
 
     # TODO (nathan): better handling of model_args
@@ -172,6 +179,7 @@ def accelerate(  # noqa C901
             "multichoice_continuations_start_space"
         ]
         args_dict["use_chat_template"] = use_chat_template
+        args_dict["generate_until_token"] = generate_until_token
 
         # Keeping only non null params
         args_dict = {k: v for k, v in args_dict.items() if v is not None}
@@ -192,6 +200,7 @@ def accelerate(  # noqa C901
         model_args_dict: dict = {k.split("=")[0]: k.split("=")[1] if "=" in k else True for k in model_args.split(",")}
         model_args_dict["accelerator"] = accelerator
         model_args_dict["use_chat_template"] = use_chat_template
+        model_args_dict["generate_until_token"] = generate_until_token
         model_args_dict["compile"] = bool(model_args_dict["compile"]) if "compile" in model_args_dict else False
         model_config = TransformersModelConfig(**model_args_dict)
 

--- a/src/lighteval/main_accelerate.py
+++ b/src/lighteval/main_accelerate.py
@@ -200,7 +200,6 @@ def accelerate(  # noqa C901
         model_args_dict: dict = {k.split("=")[0]: k.split("=")[1] if "=" in k else True for k in model_args.split(",")}
         model_args_dict["accelerator"] = accelerator
         model_args_dict["use_chat_template"] = use_chat_template
-        model_args_dict["generate_until_token"] = generate_until_token
         model_args_dict["compile"] = bool(model_args_dict["compile"]) if "compile" in model_args_dict else False
         model_config = TransformersModelConfig(**model_args_dict)
 

--- a/src/lighteval/pipeline.py
+++ b/src/lighteval/pipeline.py
@@ -108,6 +108,7 @@ class PipelineParameters:
     use_chat_template: bool = False
     system_prompt: str | None = None
     load_responses_from_details_date_id: str | None = None
+    generate_until_token: str | None = None
 
     def __post_init__(self):  # noqa C901
         if self.launcher_type == ParallelismManager.ACCELERATE:
@@ -234,6 +235,7 @@ class Pipeline:
                 evaluation_tracker=self.evaluation_tracker,
                 use_chat_template=self.pipeline_parameters.use_chat_template,
                 system_prompt=self.pipeline_parameters.system_prompt,
+                generate_until_token=self.pipeline_parameters.generate_until_token,
             )
 
             self.task_names_list = task_names_list

--- a/src/lighteval/tasks/lighteval_task.py
+++ b/src/lighteval/tasks/lighteval_task.py
@@ -582,6 +582,7 @@ def create_requests_from_tasks(  # noqa: C901
     evaluation_tracker: "EvaluationTracker",
     use_chat_template: bool,
     system_prompt: str | None,
+    generate_until_token: str | None,
 ) -> Tuple[dict[RequestType, list[Request]], dict[SampleUid, Doc]]:
     """
     Takes a task dict and a fewshot dict and returns a dict of requests, a dict
@@ -646,6 +647,7 @@ def create_requests_from_tasks(  # noqa: C901
                         truncate_few_shots=truncate_few_shots,
                         use_chat_template=use_chat_template,
                         system_prompt=system_prompt,
+                        generate_until_token=generate_until_token,
                     )
 
                     # Constructing the requests

--- a/src/lighteval/tasks/prompt_manager.py
+++ b/src/lighteval/tasks/prompt_manager.py
@@ -262,6 +262,7 @@ class PromptManager:
                     max_new_tokens=2048,
                     stop_tokens=[generate_until_token],
                 )
+                logger.debug(response[0].result[0])
                 full_start = chat_preview + response[0].result[0] + generate_until_token
                 return full_start, num_effective_fewshots
             else:

--- a/src/lighteval/tasks/prompt_manager.py
+++ b/src/lighteval/tasks/prompt_manager.py
@@ -259,6 +259,7 @@ class PromptManager:
                 )
                 response = self.model._generate(
                     batch=prepared_batch,
+                    do_sample=True,
                     max_new_tokens=2048,
                     stop_tokens=[generate_until_token],
                 )


### PR DESCRIPTION
As noted in #8 and #513 , LightEval expects models to follow a question with an immediate answer, but chain-of-thought and reasoning models (such as DeepSeek) generate many tokens to arrive at a more accurate / thought-out result before answering.

This PR would add `--generate-until-token '</think>'` as the syntax to support these models.
It must be run with `--use-chat-template` and a `TransformerModel` model, or it will raise an Exception.

I have [a CoLab notebook](https://colab.research.google.com/drive/1HJrN-OsOewvnijrwCZsTDzD_5iIWZugn?usp=sharing) running a BigBench task which I didn't run to the end, but I used `logger.info` to confirm it was generating reasoning text. In a previous test linked in #513 I confirmed this method works on a short task

Notes:
- "generate until token" or "wait until..." is the clearest name I could think of to remind people to use the ending token
- this doesn't look at the tokenizer's chat template string, but it could be helpful to detect the appropriate token
- Should I have `do_sample=True` when generating the reasoning text? Is that reproducible?
- Is there a way to see `logger.debug()` when calling lighteval from the command line? I can remove the logging of reasoning text if it isn't helpful
- For better results on my custom task in #513 , I had to change answers `["A", "B", ...]` to `["The answer is A", ...]` - thoughts about using the template string to set post-reasoning text and be compatible with more evals?