### PR TITLE
Relax spacy import to avoid dep conflict with more recent versions of gradio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ dependencies = [
     # Base metrics
     "nltk==3.9.1",
     "scikit-learn",
-    "spacy==3.7.2",
     "sacrebleu",
     "rouge_score==0.1.2",
     "sentencepiece>=0.1.99",

--- a/src/lighteval/metrics/imports/data_stats_metric.py
+++ b/src/lighteval/metrics/imports/data_stats_metric.py
@@ -28,9 +28,8 @@ import logging
 from collections import Counter
 from multiprocessing import Pool
 
-import spacy
-
 from lighteval.metrics.imports.data_stats_utils import Fragments
+from lighteval.utils.imports import NO_SPACY_ERROR_MSG, is_spacy_available
 
 
 logger = logging.getLogger(__name__)
@@ -72,6 +71,10 @@ class DataStatsMetric(Metric):
                 :param tokenize: whether to tokenize the input; otherwise assumes that the input
                     is a string of space-separated tokens
         """
+        if not is_spacy_available():
+            raise ImportError(NO_SPACY_ERROR_MSG)
+        import spacy
+
         self.n_gram = n_gram
         self.n_workers = n_workers
         self.case = case

--- a/src/lighteval/utils/imports.py
+++ b/src/lighteval/utils/imports.py
@@ -147,3 +147,10 @@ def requires_latex2sympy2_extended(func):
 
 
 NO_LATEX2SYMPY2_EXTENDED_ERROR_MSG = "You are trying to parse latex expressions, for which you need `latex2sympy2_extended`, which is not available in your environment. Please install it using `pip install lighteval[math]`."
+
+
+def is_spacy_available() -> bool:
+    return importlib.util.find_spec("spacy") is not None
+
+
+NO_SPACY_ERROR_MSG = "You are trying to use some metrics requiring `spacy`, which is not available in your environment. Please install it using pip."


### PR DESCRIPTION
Gradio relies on typer (a recent version) and spacy on an old version -> leads to conflicts, when the spacy based-metrics are imo not among the most used. So relaxing the import on this one.