### PR TITLE
Integrate huggingface_hub inference support

### DIFF
--- a/src/lighteval/metrics/llm_as_judge.py
+++ b/src/lighteval/metrics/llm_as_judge.py
@@ -85,7 +85,7 @@ class JudgeLM:
         judge_backend: Literal["litellm", "openai", "transformers", "tgi", "vllm", "inference-providers"],
         url: str | None = None,
         api_key: str | None = None,
-        max_tokens: int = 1024,
+        max_tokens: int = 512,
         response_format: BaseModel = None,
         hf_provider: Optional[
             Literal[

--- a/src/lighteval/metrics/llm_as_judge.py
+++ b/src/lighteval/metrics/llm_as_judge.py
@@ -163,7 +163,7 @@ class JudgeLM:
                 if self.pipe is None:
                     import torch
                     from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
-                    
+
                     transformers_model = AutoModelForCausalLM.from_pretrained(
                         self.model, torch_dtype=torch.float16, trust_remote_code=False, device_map="cuda"
                     )
@@ -175,7 +175,7 @@ class JudgeLM:
                         max_new_tokens=self.max_tokens,
                     )
                 return self.__call_transformers
-            
+
             case "inference-providers":
                 from huggingface_hub import AsyncInferenceClient
 

--- a/src/lighteval/metrics/llm_as_judge.py
+++ b/src/lighteval/metrics/llm_as_judge.py
@@ -123,6 +123,10 @@ class JudgeLM:
 
         self.response_format = response_format if not None else DEFAULT_FORMAT
 
+        # Validate that hf_provider is specified when using inference-providers backend
+        if self.backend == "inference-providers" and self.hf_provider is None:
+            raise ValueError("When using 'inference-providers' as backend, you must specify an 'hf_provider'")
+
     def __lazy_load_client(self):
         match self.backend:
             # Both "openai" and "tgi" backends use the OpenAI-compatible API

--- a/src/lighteval/metrics/llm_as_judge.py
+++ b/src/lighteval/metrics/llm_as_judge.py
@@ -160,10 +160,10 @@ class JudgeLM:
                 return self.__call_vllm
 
             case "transformers":
-                import torch
-                from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
-
                 if self.pipe is None:
+                    import torch
+                    from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+                    
                     transformers_model = AutoModelForCausalLM.from_pretrained(
                         self.model, torch_dtype=torch.float16, trust_remote_code=False, device_map="cuda"
                     )
@@ -175,7 +175,7 @@ class JudgeLM:
                         max_new_tokens=self.max_tokens,
                     )
                 return self.__call_transformers
-
+            
             case "inference-providers":
                 from huggingface_hub import AsyncInferenceClient
 

--- a/src/lighteval/metrics/llm_as_judge.py
+++ b/src/lighteval/metrics/llm_as_judge.py
@@ -21,16 +21,15 @@
 # SOFTWARE.
 
 
-import time
-import logging
 import asyncio
+import logging
+import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Callable, Literal, Optional, Any
+from typing import Callable, Literal, Optional
 
-from huggingface_hub import InferenceTimeoutError, AsyncInferenceClient
-from requests.exceptions import HTTPError
-
+from huggingface_hub import AsyncInferenceClient, InferenceTimeoutError
 from pydantic import BaseModel
+from requests.exceptions import HTTPError
 from tqdm import tqdm
 from tqdm.asyncio import tqdm_asyncio
 
@@ -89,7 +88,7 @@ class JudgeLM:
         max_tokens: int = 1024,
         response_format: BaseModel = None,
         hf_provider: Optional[Literal["black-forest-labs", "cerebras", "cohere", "fal-ai", "fireworks-ai", "hf-inference", "hyperbolic", "nebius", "novita", "openai", "replicate", "sambanova", "together"]] = None
-        
+
     ):
         self.model = model
         self.template = templates
@@ -321,7 +320,7 @@ class JudgeLM:
             raise ValueError("Some entries are not annotated due to errors in annotate_p, please inspect and retry.")
 
         return results
-    
+
     def __call_hf_inference_async(self, prompts):
         async def run_all() -> list[str]:
             """Wrap inference call into function"""
@@ -330,10 +329,10 @@ class JudgeLM:
 
         try:
             loop = asyncio.get_running_loop()
-            logger.debug(f"Exting event loop is found, using loop.create_task")
+            logger.debug("Exting event loop is found, using loop.create_task")
             result = loop.run_until_complete(run_all())
         except RuntimeError:
-            logger.debug(f"No running event loop found, using asyncio.run")
+            logger.debug("No running event loop found, using asyncio.run")
             result = asyncio.run(run_all())
 
         if None in result:
@@ -357,7 +356,7 @@ class JudgeLM:
             except Exception as e:
                 logger.warning(f"Unexpected error during HF inference: {e}")
                 await asyncio.sleep(self.API_RETRY_SLEEP)
-        
+
         raise Exception("Failed to get response from the HF API")
 
     def __call_api_parallel(self, prompts):

--- a/src/lighteval/metrics/llm_as_judge.py
+++ b/src/lighteval/metrics/llm_as_judge.py
@@ -87,8 +87,23 @@ class JudgeLM:
         api_key: str | None = None,
         max_tokens: int = 1024,
         response_format: BaseModel = None,
-        hf_provider: Optional[Literal["black-forest-labs", "cerebras", "cohere", "fal-ai", "fireworks-ai", "hf-inference", "hyperbolic", "nebius", "novita", "openai", "replicate", "sambanova", "together"]] = None
-
+        hf_provider: Optional[
+            Literal[
+                "black-forest-labs",
+                "cerebras",
+                "cohere",
+                "fal-ai",
+                "fireworks-ai",
+                "hf-inference",
+                "hyperbolic",
+                "nebius",
+                "novita",
+                "openai",
+                "replicate",
+                "sambanova",
+                "together",
+            ]
+        ] = None,
     ):
         self.model = model
         self.template = templates
@@ -117,9 +132,9 @@ class JudgeLM:
                     raise RuntimeError("OpenAI backend is not available.")
                 if self.client is None:
                     from openai import OpenAI
+
                     self.client = OpenAI(
-                        api_key=self.api_key if self.url is None else None,
-                        base_url=self.url if self.url else None
+                        api_key=self.api_key if self.url is None else None, base_url=self.url if self.url else None
                     )
                 return self.__call_api_parallel
 
@@ -135,16 +150,9 @@ class JudgeLM:
                     from vllm import LLM, SamplingParams
                     from vllm.transformers_utils.tokenizer import get_tokenizer
 
-                    self.sampling_params = SamplingParams(
-                        temperature=0.8, top_p=0.95, max_tokens=self.max_tokens
-                    )
+                    self.sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=self.max_tokens)
                     self.tokenizer = get_tokenizer(self.model, tokenizer_mode="auto")
-                    self.pipe = LLM(
-                        model=self.model,
-                        max_model_len=2048,
-                        gpu_memory_utilization=0.5,
-                        dtype="float16"
-                    )
+                    self.pipe = LLM(model=self.model, max_model_len=2048, gpu_memory_utilization=0.5, dtype="float16")
                 return self.__call_vllm
 
             case "transformers":
@@ -167,9 +175,7 @@ class JudgeLM:
             case "hf-inference":
                 from huggingface_hub import AsyncInferenceClient
 
-                self.client = AsyncInferenceClient(
-                    token=self.api_key, base_url=self.url, provider=self.hf_provider
-                )
+                self.client = AsyncInferenceClient(token=self.api_key, base_url=self.url, provider=self.hf_provider)
                 return self.__call_hf_inference_async
 
             case _:
@@ -223,7 +229,6 @@ class JudgeLM:
         golds: list[str] | list[None],
         **kwargs,
     ):
-
         judge_function = self.__lazy_load_client()
 
         kwargss = self.dict_of_lists_to_list_of_dicts(kwargs)

--- a/src/lighteval/metrics/llm_as_judge.py
+++ b/src/lighteval/metrics/llm_as_judge.py
@@ -82,7 +82,7 @@ class JudgeLM:
         model: str,
         templates: Callable,
         process_judge_response: Callable,
-        judge_backend: Literal["litellm", "openai", "transformers", "tgi", "vllm", "hf-inference"],
+        judge_backend: Literal["litellm", "openai", "transformers", "tgi", "vllm", "inference-providers"],
         url: str | None = None,
         api_key: str | None = None,
         max_tokens: int = 1024,
@@ -94,7 +94,7 @@ class JudgeLM:
                 "cohere",
                 "fal-ai",
                 "fireworks-ai",
-                "hf-inference",
+                "inference-providers",
                 "hyperbolic",
                 "nebius",
                 "novita",
@@ -172,7 +172,7 @@ class JudgeLM:
                     )
                 return self.__call_transformers
 
-            case "hf-inference":
+            case "inference-providers":
                 from huggingface_hub import AsyncInferenceClient
 
                 self.client = AsyncInferenceClient(token=self.api_key, base_url=self.url, provider=self.hf_provider)

--- a/src/lighteval/metrics/metrics_sample.py
+++ b/src/lighteval/metrics/metrics_sample.py
@@ -875,7 +875,7 @@ class JudgeLLM:
         judge_backend: Literal["litellm", "openai", "transformers", "vllm", "tgi", "inference-providers"],
         short_judge_name: str | None = None,
         response_format: BaseModel = None,
-        base_url: str | None = None,
+        url: str | None = None,
         hf_provider: str | None = None,
         max_tokens: int | None = None,
     ) -> None:
@@ -892,8 +892,8 @@ class JudgeLLM:
 
             case "tgi":
                 api_key = os.getenv("HF_TOKEN")
-                if base_url is None:
-                    base_url = "https://api-inference.huggingface.co/v1/"
+                if url is None:
+                    url = "https://api-inference.huggingface.co/v1/"
                 logger.debug("Using TGI backend")
 
             case "inference-providers":
@@ -922,7 +922,7 @@ class JudgeLLM:
             judge_backend=judge_backend,
             response_format=response_format,
             api_key=api_key,
-            url=base_url,
+            url=url,
             hf_provider=hf_provider,
             max_tokens=max_tokens,
         )

--- a/src/lighteval/metrics/metrics_sample.py
+++ b/src/lighteval/metrics/metrics_sample.py
@@ -872,7 +872,7 @@ class JudgeLLM:
         judge_model_name: str,
         template: Callable,
         process_judge_response: Callable,
-        judge_backend: Literal["litellm", "openai", "transformers", "vllm", "tgi", "hf-inference"],
+        judge_backend: Literal["litellm", "openai", "transformers", "vllm", "tgi", "inference-providers"],
         short_judge_name: str | None = None,
         response_format: BaseModel = None,
         base_url: str | None = None,
@@ -896,7 +896,7 @@ class JudgeLLM:
                     base_url = "https://api-inference.huggingface.co/v1/"
                 logger.debug("Using TGI backend")
 
-            case "hf-inference":
+            case "inference-providers":
                 api_key = os.getenv("HF_TOKEN")
                 logger.debug("Using Hugging Face Inference backend")
 

--- a/src/lighteval/metrics/metrics_sample.py
+++ b/src/lighteval/metrics/metrics_sample.py
@@ -892,7 +892,8 @@ class JudgeLLM:
 
             case "tgi":
                 api_key = os.getenv("HF_TOKEN")
-                url = "https://api-inference.huggingface.co/v1/"
+                if base_url is None:
+                    base_url = "https://api-inference.huggingface.co/v1/"
                 logger.debug("Using TGI backend")
 
             case "hf-inference":

--- a/src/lighteval/metrics/metrics_sample.py
+++ b/src/lighteval/metrics/metrics_sample.py
@@ -872,31 +872,45 @@ class JudgeLLM:
         judge_model_name: str,
         template: Callable,
         process_judge_response: Callable,
-        judge_backend: Literal["litellm", "openai", "transformers", "vllm", "tgi"],
+        judge_backend: Literal["litellm", "openai", "transformers", "vllm", "tgi", "hf-inference"],
         short_judge_name: str | None = None,
         response_format: BaseModel = None,
+        base_url: str | None = None,
+        hf_provider: str | None = None,
+        max_tokens: int | None = None,
     ) -> None:
+        logger.debug(f"Initializing JudgeLLM with backend: {judge_backend}, model: {judge_model_name}")
+
+        api_key = None
+    
         match judge_backend:
             case "openai":
                 if judge_model_name not in self.available_models_openai:
-                    raise ValueError(f"{judge_model_name} not in available models for llm as a judge metric")
-                else:
-                    api_key = os.getenv("OPENAI_API_KEY")
-                    url = None
+                    raise ValueError(f"{judge_model_name} not in available OpenAI models")
+                api_key = os.getenv("OPENAI_API_KEY")
+                logger.debug("Using OpenAI backend")
+
             case "tgi":
                 api_key = os.getenv("HF_TOKEN")
                 url = "https://api-inference.huggingface.co/v1/"
+                logger.debug("Using TGI backend")
+
+            case "hf-inference":
+                api_key = os.getenv("HF_TOKEN")
+                logger.debug("Using Hugging Face Inference backend")
+
             case "litellm":
-                api_key = None
-                url = None
+                logger.debug("Using LiteLLM backend")
+
             case "transformers" | "vllm":
+                logger.debug("Checking availability of Transformers or VLLM model")
                 api = HfApi()
                 models = api.list_models(model_name=judge_model_name)
-                url = None
-                api_key = None
                 if not models:
-                    raise ValueError(f"{judge_model_name} not in available models for llm as a judge metric")
+                    raise ValueError(f"{judge_model_name} not found on Hugging Face Hub")
+
             case _:
+                logger.error(f"Invalid judge backend provided: {judge_backend}")
                 raise ValueError(f"{judge_backend} is not a valid backend for llm as a judge metric")
 
         self.short_judge_name = short_judge_name
@@ -904,10 +918,12 @@ class JudgeLLM:
             model=judge_model_name,
             templates=template,
             process_judge_response=process_judge_response,
-            api_key=api_key,
-            url=url,
             judge_backend=judge_backend,
             response_format=response_format,
+            api_key=api_key,
+            url=base_url,
+            hf_provider=hf_provider,
+            max_tokens=max_tokens,
         )
 
     def compute(self, predictions: list[str], formatted_doc: Doc, **kwargs) -> dict[str, float]:

--- a/src/lighteval/metrics/metrics_sample.py
+++ b/src/lighteval/metrics/metrics_sample.py
@@ -886,9 +886,9 @@ class JudgeLLM:
         match judge_backend:
             case "openai":
                 if judge_model_name not in self.available_models_openai:
-                    raise ValueError(f"{judge_model_name} not in available OpenAI models")
+                    raise ValueError(f"{judge_model_name} not in available models for llm as a judge metric")
                 api_key = os.getenv("OPENAI_API_KEY")
-                logger.debug("Using OpenAI backend")
+                logger.debug("Using OpenAI backend for llm as a judge metric")
 
             case "tgi":
                 api_key = os.getenv("HF_TOKEN")
@@ -901,7 +901,7 @@ class JudgeLLM:
                 logger.debug("Using Hugging Face Inference backend")
 
             case "litellm":
-                logger.debug("Using LiteLLM backend")
+                logger.debug("Using LiteLLM backend for llm as a judge metric")
 
             case "transformers" | "vllm":
                 logger.debug("Checking availability of Transformers or VLLM model")
@@ -911,7 +911,6 @@ class JudgeLLM:
                     raise ValueError(f"{judge_model_name} not found on Hugging Face Hub")
 
             case _:
-                logger.error(f"Invalid judge backend provided: {judge_backend}")
                 raise ValueError(f"{judge_backend} is not a valid backend for llm as a judge metric")
 
         self.short_judge_name = short_judge_name

--- a/src/lighteval/metrics/metrics_sample.py
+++ b/src/lighteval/metrics/metrics_sample.py
@@ -882,7 +882,7 @@ class JudgeLLM:
         logger.debug(f"Initializing JudgeLLM with backend: {judge_backend}, model: {judge_model_name}")
 
         api_key = None
-    
+
         match judge_backend:
             case "openai":
                 if judge_model_name not in self.available_models_openai:


### PR DESCRIPTION
- Integrated Hugging Face Inference (`hf-inference`) as a new backend option for judge model evaluation.
- Added async inference logic using `AsyncInferenceClient` only for `hf-inference`, with support for retries, timeouts, and provider specification.
- Extended `JudgeLM` and `JudgeLLM` classes to support new configuration parameters like `hf_provider`, `base_url`, and `max_tokens`.