### PR TITLE
add cot_prompt in vllm

### DIFF
--- a/src/lighteval/main_vllm.py
+++ b/src/lighteval/main_vllm.py
@@ -52,6 +52,9 @@ def vllm(
     system_prompt: Annotated[
         Optional[str], Option(help="Use system prompt for evaluation.", rich_help_panel=HELP_PANEL_NAME_4)
     ] = None,
+    cot_prompt: Annotated[
+        Optional[str], Option(help="Use chain of thought prompt for evaluation.", rich_help_panel=HELP_PANEL_NAME_4)
+    ] = None,
     dataset_loading_processes: Annotated[
         int, Option(help="Number of processes to use for dataset loading.", rich_help_panel=HELP_PANEL_NAME_1)
     ] = 1,
@@ -128,6 +131,7 @@ def vllm(
         max_samples=max_samples,
         use_chat_template=use_chat_template,
         system_prompt=system_prompt,
+        cot_prompt=cot_prompt,
         load_responses_from_details_date_id=load_responses_from_details_date_id,
     )
 

--- a/src/lighteval/pipeline.py
+++ b/src/lighteval/pipeline.py
@@ -107,6 +107,7 @@ class PipelineParameters:
     max_samples: int | None = None
     use_chat_template: bool = False
     system_prompt: str | None = None
+    cot_prompt: str | None = None
     load_responses_from_details_date_id: str | None = None
 
     def __post_init__(self):  # noqa C901
@@ -236,6 +237,7 @@ class Pipeline:
                 evaluation_tracker=self.evaluation_tracker,
                 use_chat_template=self.pipeline_parameters.use_chat_template,
                 system_prompt=self.pipeline_parameters.system_prompt,
+                cot_prompt=self.pipeline_parameters.cot_prompt,
             )
 
             self.task_names_list = task_names_list

--- a/src/lighteval/tasks/lighteval_task.py
+++ b/src/lighteval/tasks/lighteval_task.py
@@ -582,6 +582,7 @@ def create_requests_from_tasks(  # noqa: C901
     evaluation_tracker: "EvaluationTracker",
     use_chat_template: bool,
     system_prompt: str | None,
+    cot_prompt: str | None,
 ) -> Tuple[dict[RequestType, list[Request]], dict[SampleUid, Doc]]:
     """
     Takes a task dict and a fewshot dict and returns a dict of requests, a dict
@@ -599,6 +600,8 @@ def create_requests_from_tasks(  # noqa: C901
         max_samples (int): maximum number of samples.
         evaluation_tracker (EvaluationTracker): evaluation tracker.
         use_chat_template (bool): Whether to use the chat template.
+        system_prompt (str): System prompt
+        cot_prompt (str): Chain of thought prompt
 
     Raises:
         NotImplementedError: If the request type is not implemented for the
@@ -646,6 +649,7 @@ def create_requests_from_tasks(  # noqa: C901
                         truncate_few_shots=truncate_few_shots,
                         use_chat_template=use_chat_template,
                         system_prompt=system_prompt,
+                        cot_prompt=cot_prompt,
                     )
 
                     # Constructing the requests


### PR DESCRIPTION
Add Cot prompt argument. https://github.com/huggingface/lighteval/issues/8

cot prompt is appended after example. 

```python
        # Actual example
        content = example + cot_prompt if cot_prompt is not None else example

        if use_chat_template:
            examples.append({"role": "user", "content": content})
        else:
            examples.append(content)
```