### PR TITLE
Use `n=16` samples to estimate `pass@1` for AIME benchmarks

### DIFF
--- a/src/lighteval/tasks/default_tasks.py
+++ b/src/lighteval/tasks/default_tasks.py
@@ -328,8 +328,6 @@ aime24 = LightevalTaskConfig(
         Metrics.math_pass_at_1_4n,
         Metrics.math_pass_at_1_8n,
         Metrics.math_pass_at_1_16n,
-        Metrics.math_pass_at_1_32n,
-        Metrics.math_pass_at_1_64n,
     ],
     version=1,
 )
@@ -349,8 +347,6 @@ aime25 = LightevalTaskConfig(
         Metrics.math_pass_at_1_4n,
         Metrics.math_pass_at_1_8n,
         Metrics.math_pass_at_1_16n,
-        Metrics.math_pass_at_1_32n,
-        Metrics.math_pass_at_1_64n,
     ],
     version=1,
 )

--- a/src/lighteval/tasks/default_tasks.py
+++ b/src/lighteval/tasks/default_tasks.py
@@ -325,8 +325,6 @@ aime24 = LightevalTaskConfig(
     generation_size=32768,
     metric=[
         Metrics.expr_gold_metric,
-        Metrics.math_pass_at_1_4n,
-        Metrics.math_pass_at_1_8n,
         Metrics.math_pass_at_1_16n,
     ],
     version=1,
@@ -344,8 +342,6 @@ aime25 = LightevalTaskConfig(
     generation_size=10000,
     metric=[
         Metrics.expr_gold_metric,
-        Metrics.math_pass_at_1_4n,
-        Metrics.math_pass_at_1_8n,
         Metrics.math_pass_at_1_16n,
     ],
     version=1,


### PR DESCRIPTION
Currently we estimate `pass@1` from various values of `n` in the range `[4,8,16,32,64]`. Since large values of `n` are expensive to run, I compared the variance across various reasoning models on AIME24 using 10 different seeds. As shown in the figures below, we can take `n=16` as a good compromise between compute and variance, with about a 1 percentage point variance across runs. 

Questions:

* I removed `math_pass_at_1_4n` and `math_pass_at_1_8n` because I wasn't sure if these are computed independently of `math_pass_at_1_16n` or obtained via subsampling? If the former, I propose to remove them to avoid redundant computation.

![DeepSeek-R1-Distill-Llama-8B_math_pass_plot](https://github.com/user-attachments/assets/a644b021-4783-48b3-95a6-bcf03243e889)
![DeepSeek-R1-Distill-Qwen-14B_math_pass_plot](https://github.com/user-attachments/assets/ea3ddc54-7d32-4636-a9e4-551c8b60ab2e)
![DeepSeek-R1-Distill-Qwen-7B_math_pass_plot](https://github.com/user-attachments/assets/7ee10268-8d06-40ae-aa34-c8ae927ce83f)
![DeepSeek-R1-Distill-Qwen-1 5B_math_pass_plot](https://github.com/user-attachments/assets/03158d0f-7bde-457e-a410-7ac0525eb1f7)
