### PR TITLE
Align AIME pass@1 with literature

### DIFF
--- a/src/lighteval/tasks/default_tasks.py
+++ b/src/lighteval/tasks/default_tasks.py
@@ -325,7 +325,7 @@ aime24 = LightevalTaskConfig(
     generation_size=32768,
     metric=[
         Metrics.expr_gold_metric,
-        Metrics.math_pass_at_1_16n,
+        Metrics.math_pass_at_1_32n,
     ],
     version=1,
 )
@@ -342,7 +342,7 @@ aime25 = LightevalTaskConfig(
     generation_size=10000,
     metric=[
         Metrics.expr_gold_metric,
-        Metrics.math_pass_at_1_16n,
+        Metrics.math_pass_at_1_32n,
     ],
     version=1,
 )


### PR DESCRIPTION
Recent papers like [SimpleRL-Zoo](https://arxiv.org/pdf/2503.18892) and [VAPO](https://arxiv.org/pdf/2504.05118) have adopted `n=32` as the default estimate for AIME24. 

This PR bumps our default to the same value so we align with what others report. See https://github.com/huggingface/lighteval/pull/661 for more details on the variance across `n` values.