### PR TITLE
Lift protobuf restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "sacrebleu",
     "rouge_score==0.1.2",
     "sentencepiece>=0.1.99",
-    "protobuf", # pinned for sentencepiece compat
+    "protobuf",
     "pycountry",
     "fsspec>=2023.12.2",
     "httpx == 0.27.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "sacrebleu",
     "rouge_score==0.1.2",
     "sentencepiece>=0.1.99",
-    "protobuf==3.20.*", # pinned for sentencepiece compat
+    "protobuf", # pinned for sentencepiece compat
     "pycountry",
     "fsspec>=2023.12.2",
     "httpx == 0.27.2",

--- a/src/lighteval/models/transformers/transformers_model.py
+++ b/src/lighteval/models/transformers/transformers_model.py
@@ -454,7 +454,7 @@ class TransformersModel(LightevalModel):
                 return getattr(self.transformers_config, attr)
 
         logger.warning(
-            "No max_length attribute found in the model config. Using the default max sequence length setting {2048}. It is recomended to set max_length trough the madel args"
+            "No max_length attribute found in the model config. Using the default max sequence length setting {2048}. It is recomended to set max_length through the model args"
         )
 
         return 2048


### PR DESCRIPTION
Is it still necessary to use a 3 year-old version of protobuf? I've been trying to integrate with a larger code base, and having trouble with conflicting dependencies. Lifting the restriction fixes that for me.