### PR TITLE
Fix TransformersModel.from_model() method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "sacrebleu",
     "rouge_score==0.1.2",
     "sentencepiece>=0.1.99",
-    "protobuf", # pinned for sentencepiece compat
+    "protobuf",
     "pycountry",
     "fsspec>=2023.12.2",
     "httpx == 0.27.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "sacrebleu",
     "rouge_score==0.1.2",
     "sentencepiece>=0.1.99",
-    "protobuf==3.20.*", # pinned for sentencepiece compat
+    "protobuf", # pinned for sentencepiece compat
     "pycountry",
     "fsspec>=2023.12.2",
     "httpx == 0.27.2",

--- a/src/lighteval/models/transformers/transformers_model.py
+++ b/src/lighteval/models/transformers/transformers_model.py
@@ -266,10 +266,8 @@ class TransformersModel(LightevalModel):
         if accelerator is not None:
             self._device = accelerator.device
             self.model = self.accelerator.prepare(self.model.to(accelerator.device))
-        elif self.config.device is not None:
-            self._device = self.config.device
         else:
-            self._device = "cpu"
+            self._device = self.config.device
 
         self.use_chat_template = use_chat_template
         self._add_special_tokens = add_special_tokens if add_special_tokens is not None else False

--- a/src/lighteval/models/transformers/transformers_model.py
+++ b/src/lighteval/models/transformers/transformers_model.py
@@ -266,6 +266,8 @@ class TransformersModel(LightevalModel):
         if accelerator is not None:
             self._device = accelerator.device
             self.model = self.accelerator.prepare(self.model.to(accelerator.device))
+        elif self.config.device is not None:
+            self._device = self.config.device
         else:
             self._device = "cpu"
 

--- a/src/lighteval/models/transformers/transformers_model.py
+++ b/src/lighteval/models/transformers/transformers_model.py
@@ -454,7 +454,7 @@ class TransformersModel(LightevalModel):
                 return getattr(self.transformers_config, attr)
 
         logger.warning(
-            "No max_length attribute found in the model config. Using the default max sequence length setting {2048}. It is recomended to set max_length trough the madel args"
+            "No max_length attribute found in the model config. Using the default max sequence length setting {2048}. It is recomended to set max_length through the model args"
         )
 
         return 2048


### PR DESCRIPTION
The original version of this code simply does not work. It makes references to methods and arguments that do not exist, and is completely non-functional in its current form.

I have made some minor revisions, which will allow a user to pass an already-instantiated `AutoModelForCausalLM` instance to this method, along with a `TransformersModelConfig` instance, to bypass `__init__` and create a `TransformersModel` - sharing resources with the original model. I've tested this code extensively, and it seems to work well for me.

I am doing this because I want to evaluate a model that is already loaded, and I don't want to duplicate its resources by loading a 2nd copy from disk.

FYI, this branch currently has a dependence on https://github.com/huggingface/lighteval/pull/683, since I can't develop without it.

Let me know if you have any questions!