### PR TITLE
Fix tqdm logging

### DIFF
--- a/src/lighteval/metrics/stderr.py
+++ b/src/lighteval/metrics/stderr.py
@@ -26,6 +26,7 @@
 
 import logging
 import math
+import os
 import random
 from typing import Callable, Optional
 
@@ -35,6 +36,8 @@ from tqdm import tqdm
 
 
 logger = logging.getLogger(__name__)
+
+LIGHTEVAL_DISABLE_TQDM = int(os.environ.get("LIGHTEVAL_DISABLE_TQDM", "0"))
 
 
 def _stddev(arr):
@@ -66,7 +69,7 @@ class _bootstrap_internal:
                     [(rnd.choices(population, k=len(population)),) for _ in range(self.number_draws)],
                     total=self.number_draws,
                     desc="Sampling bootstrap iterations",
-                    disable=True,
+                    disable=bool(LIGHTEVAL_DISABLE_TQDM),
                 ),
             )
         return samplings

--- a/src/lighteval/metrics/stderr.py
+++ b/src/lighteval/metrics/stderr.py
@@ -66,6 +66,7 @@ class _bootstrap_internal:
                     [(rnd.choices(population, k=len(population)),) for _ in range(self.number_draws)],
                     total=self.number_draws,
                     desc="Sampling bootstrap iterations",
+                    disable=True,
                 ),
             )
         return samplings

--- a/src/lighteval/models/transformers/transformers_model.py
+++ b/src/lighteval/models/transformers/transformers_model.py
@@ -763,7 +763,7 @@ class TransformersModel(LightevalModel):
         starting_batch_size = STARTING_BATCH_SIZE
         res = []
 
-        for split in tqdm(dataset.splits_iterator()):
+        for split in tqdm(dataset.splits_iterator(), disable=self.disable_tqdm):
             context_enc = split[0].tokenized_context
             continuation_enc = split[0].tokenized_continuation
             if rolling:  # we take all the sequence in rolling mode
@@ -1007,7 +1007,7 @@ class TransformersModel(LightevalModel):
         starting_batch_size = STARTING_BATCH_SIZE
         res = []
 
-        for split in tqdm(dataset.splits_iterator()):
+        for split in tqdm(dataset.splits_iterator(), disable=self.disable_tqdm):
             context_enc = split[0].tokenized_context
             max_context = len(context_enc[-self.max_length :])
             batch_size = self._get_batch_size(override_bs=self.config.batch_size, max_input_length=max_context)


### PR DESCRIPTION
This PR ensures that TQDM is actually disabled, when `self.disable_tqdm = True`. 

It also disables TQDM during stderr calculation, since that process is nearly instantaneous, and tells you nothing - it seems like an unnecessary notification. Alternatively, if preferable to you, we could implement something like a `LIGHTEVAL_DISABLE_TQDM` flag, to handle suppression of other outputs.