### PR TITLE
Fix revision arg for vLLM tokenizer

### DIFF
--- a/src/lighteval/models/vllm/vllm_model.py
+++ b/src/lighteval/models/vllm/vllm_model.py
@@ -204,7 +204,7 @@ class VLLMModel(LightevalModel):
             config.model_name,
             tokenizer_mode="auto",
             trust_remote_code=config.trust_remote_code,
-            tokenizer_revision=config.revision,
+            revision=config.revision,
         )
         tokenizer.pad_token = tokenizer.eos_token
         return tokenizer

--- a/tests/models/vllm/test_vllm_model.py
+++ b/tests/models/vllm/test_vllm_model.py
@@ -30,7 +30,7 @@ from lighteval.models.vllm.vllm_model import VLLMModel, VLLMModelConfig
 class TestVLLMTokenizerCreation(unittest.TestCase):
     def test_tokenizer_created_with_correct_revision(self):
         config = VLLMModelConfig(
-            model_name="lighteval-internal-testing/different-chat-templates-per-revision", revision="new_chat_template"
+            model_name="lighteval/different-chat-templates-per-revision", revision="new_chat_template"
         )
         vllm_tokenizer = VLLMModel.__new__(VLLMModel)._create_auto_tokenizer(config)
         tokenizer = AutoTokenizer.from_pretrained(

--- a/tests/models/vllm/test_vllm_model.py
+++ b/tests/models/vllm/test_vllm_model.py
@@ -1,0 +1,40 @@
+# MIT License
+
+# Copyright (c) 2025 The HuggingFace Team
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import unittest
+
+from transformers import AutoTokenizer
+
+from lighteval.models.vllm.vllm_model import VLLMModel, VLLMModelConfig
+
+
+class TestVLLMTokenizerCreation(unittest.TestCase):
+    def test_tokenizer_created_with_correct_revision(self):
+        config = VLLMModelConfig(
+            model_name="lewtun/different-chat-templates-per-revision", revision="new_chat_template"
+        )
+        vllm_tokenizer = VLLMModel.__new__(VLLMModel)._create_auto_tokenizer(config)
+        tokenizer = AutoTokenizer.from_pretrained(
+            config.model_name,
+            revision=config.revision,
+        )
+        self.assertEqual(vllm_tokenizer.chat_template, tokenizer.chat_template)

--- a/tests/models/vllm/test_vllm_model.py
+++ b/tests/models/vllm/test_vllm_model.py
@@ -30,7 +30,7 @@ from lighteval.models.vllm.vllm_model import VLLMModel, VLLMModelConfig
 class TestVLLMTokenizerCreation(unittest.TestCase):
     def test_tokenizer_created_with_correct_revision(self):
         config = VLLMModelConfig(
-            model_name="lewtun/different-chat-templates-per-revision", revision="new_chat_template"
+            model_name="lighteval-internal-testing/different-chat-templates-per-revision", revision="new_chat_template"
         )
         vllm_tokenizer = VLLMModel.__new__(VLLMModel)._create_auto_tokenizer(config)
         tokenizer = AutoTokenizer.from_pretrained(


### PR DESCRIPTION
This PR fixes a nasty bug where the tokenizer revision is set to the default value of `main`, irrespective of the revision provided in the model config. The reason is because `tokenizer_revision` is not a proper kwarg for `get_tokenizer()`, so we always default to `main` when loading the tokenizer in `vllm`.

Tested on this dummy model which has different chat templates on the `main` and `new_chat_template` branches: https://huggingface.co/lighteval/different-chat-templates-per-revision

The unit test fails on main with (as expected):

```
E       AssertionError: 'chat-template-on-main' != 'chat-template-on-revision'
E       - chat-template-on-main
E       ?                  ^^
E       + chat-template-on-revision
E       ?                  ^^^ +++

tests/models/vllm/test_vllm_model.py:17: AssertionError
```

It passes on this branch :)