### PR TITLE
Add org_to_bill parameter to documentation

### DIFF
--- a/docs/source/use-inference-providers-as-backend.mdx
+++ b/docs/source/use-inference-providers-as-backend.mdx
@@ -39,3 +39,6 @@ model_parameters:
     top_k: 10
     max_new_tokens: 10000
 ```
+
+By default, inference requests are billed to your personal account.
+Optionally, you can charge them to an organization by setting `org_to_bill="<your_org_name>"` (requires being a member of that organization).


### PR DESCRIPTION
I just added a line about billing options,
explaining that requests can be charged to an organization using org_to_bill="<your_org_name>".