### PR TITLE
[#794] Fix: Assign SummaCZS instance to `self.summac` in Faithfulness metric

### DIFF
--- a/src/lighteval/metrics/metrics_sample.py
+++ b/src/lighteval/metrics/metrics_sample.py
@@ -696,7 +696,9 @@ class Faithfulness:
             dict[str, float]: The faithfulness scores.
         """
         if self.summac is None:
-            SummaCZS(granularity="sentence", model_name="vitc", imager_load_cache=False)  # , device=device)
+            self.summac = SummaCZS(
+                granularity="sentence", model_name="vitc", imager_load_cache=False
+            )  # , device=device)
         inp = formatted_doc.specific[self.input_column]
         prediction = predictions[0]
         if self.normalize_input:


### PR DESCRIPTION
This PR fixes the Faithfulness metric by assigning the SummaCZS instance to self.summac  per issue #794 

Previously, the SummaCZS model was instantiated but not assigned, causing `self.summac` to remain `None` and leading to runtime errors during scoring. This fix ensures the model is correctly cached in `self.summac`.