### PR TITLE
Catch ROCM/HIP/AMD oom in `should_reduce_batch_size`

### DIFF
--- a/src/lighteval/utils/parallelism.py
+++ b/src/lighteval/utils/parallelism.py
@@ -50,6 +50,7 @@ def should_reduce_batch_size(exception: Exception) -> bool:
         "CUDA out of memory.",  # CUDA OOM
         "cuDNN error: CUDNN_STATUS_NOT_SUPPORTED.",  # CUDNN SNAFU
         "DefaultCPUAllocator: can't allocate memory",  # CPU OOM
+        "HIP out of memory", # ROCM OOM
     ]
     if isinstance(exception, RuntimeError) and len(exception.args) == 1:
         return any(err in exception.args[0] for err in _statements)


### PR DESCRIPTION
The ROCM/HIP/AMD oom message is missing from `should_reduce_batch_size` in utils meaning that an OOM occurs during start up on AMD GPUs. Super simple fix :)