### PR TITLE
Fix DP>1 & TP>1 evals with vllm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ nanotron = [
   "tensorboardX"
 ]
 tensorboardX = ["tensorboardX"]
-vllm = ["vllm>=0.8.4", "ray", "more_itertools"]
+vllm = ["vllm>=0.8.5.post1", "ray", "more_itertools"]
 quality = ["ruff>=v0.11.0","pre-commit"]
 tests = ["pytest>=7.4.0","deepdiff"]
 dev = ["lighteval[accelerate,quality,tests,multilingual,math,extended_tasks,vllm]"]

--- a/src/lighteval/models/vllm/vllm_model.py
+++ b/src/lighteval/models/vllm/vllm_model.py
@@ -399,6 +399,7 @@ class VLLMModel(LightevalModel):
             sampling_params.detokenize = False
 
         if self.data_parallel_size > 1:
+
             @ray.remote(num_gpus=self.tensor_parallel_size)
             def run_inference_one_model(model_args: dict, sampling_params: SamplingParams, requests):
                 llm = LLM(**model_args)


### PR DESCRIPTION
Tested using 

```
VLLM_WORKER_MULTIPROC_METHOD=spawn lighteval vllm model_name=HuggingFaceTB/SmolLM3-11T-32k-v1-transformers,dtype=bfloat16,data_parallel_size=2,tensor_parallel_size=2--output-dir outputs-ruler --save-details 'lighteval|ruler_32768:niah_multiquery|0|0' --max-samples 10
```

Before this fix, ray was complaining that it couldnt find GPUs
```
[36m(run_inference_one_model pid=2816485)[0m ValueError: Current node has no GPU available. current_node_resource={'CPU': 96.0, 'node:__internal_head__': 1.0, 'node:26.0.174.186': 1.0, 'memory': 1824080048128.0, 'object_store_memory': 200000000000.0}. vLLM engine cannot start without GPU. Make sure you have at least 1 GPU available in a node 
```