### PR TITLE
Fix typo in attribute name: CONCURENT_CALLS -> CONCURRENT_CALLS

### DIFF
--- a/src/lighteval/models/litellm_model.py
+++ b/src/lighteval/models/litellm_model.py
@@ -123,7 +123,7 @@ class LiteLLMClient(LightevalModel):
         self.API_MAX_RETRY = 5
         self.API_RETRY_SLEEP = 3
         self.API_RETRY_MULTIPLIER = 2
-        self.CONCURENT_CALLS = 10  # 100 leads to hitting Anthropic rate limits
+        self.CONCURRENT_CALLS = 10  # 100 leads to hitting Anthropic rate limits
 
         self._tokenizer = encode
         self.pairwise_tokenization = False
@@ -232,7 +232,7 @@ class LiteLLMClient(LightevalModel):
             f"Length of prompts, return_logitss, max_new_tokenss, num_sampless, stop_sequences, system_prompts should be the same but are {len(prompts)}, {len(return_logitss)}, {len(max_new_tokenss)}, {len(num_sampless)}, {len(stop_sequencess)}"
         )
 
-        with ThreadPoolExecutor(self.CONCURENT_CALLS) as executor:
+        with ThreadPoolExecutor(self.CONCURRENT_CALLS) as executor:
             for entry in tqdm(
                 executor.map(
                     self.__call_api,


### PR DESCRIPTION
This PR renames `LiteLLMClient.CONCURENT_CALLS` to `LiteLLMClient.CONCURRENT_CALLS`.

This attribute only appears in two places in the repository.
```
~/D/d/lighteval ❯❯❯ git log -n 1
commit d805f9fa0a84da9ca4c0c6a638bbed149a7012a3 (HEAD -> main, origin/main, origin/HEAD)
Author: Clémentine Fourrier <22726840+clefourrier@users.noreply.github.com>
Date:   Thu Jul 17 09:28:24 2025 +0200

    Remove datasets 4 from pyproject (#863)
~/D/d/lighteval ❯❯❯ git grep CONCURENT_CALLS
src/lighteval/models/litellm_model.py:        self.CONCURENT_CALLS = 10  # 100 leads to hitting Anthropic rate limits
src/lighteval/models/litellm_model.py:        with ThreadPoolExecutor(self.CONCURENT_CALLS) as executor:
```