### PR TITLE
fix tasks list

### DIFF
--- a/community_tasks/aimo_evals.py
+++ b/community_tasks/aimo_evals.py
@@ -49,7 +49,7 @@ task = LightevalTaskConfig(
     evaluation_splits=["train"],
     few_shots_split="train",
     few_shots_select="sequential",
-    metric=[Metrics.quasi_exact_match_math],
+    metrics=[Metrics.quasi_exact_match_math],
     generation_size=2048,
     stop_sequence=None,
 )

--- a/community_tasks/german_rag_evals.py
+++ b/community_tasks/german_rag_evals.py
@@ -162,7 +162,7 @@ task1 = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split="test",
     few_shots_select="sequential",
-    metric=[Metrics.loglikelihood_acc],
+    metrics=[Metrics.loglikelihood_acc],
     version=1,
 )
 
@@ -179,7 +179,7 @@ task2 = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split="test",
     few_shots_select="sequential",
-    metric=[Metrics.loglikelihood_acc],
+    metrics=[Metrics.loglikelihood_acc],
     version=1,
 )
 
@@ -197,7 +197,7 @@ task3 = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split="test",
     few_shots_select="sequential",
-    metric=[Metrics.loglikelihood_acc],
+    metrics=[Metrics.loglikelihood_acc],
     version=1,
 )
 
@@ -214,7 +214,7 @@ task4 = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split="test",
     few_shots_select="sequential",
-    metric=[Metrics.loglikelihood_acc],
+    metrics=[Metrics.loglikelihood_acc],
     version=1,
 )
 

--- a/community_tasks/oz_evals.py
+++ b/community_tasks/oz_evals.py
@@ -78,7 +78,7 @@ oz_eval_task = LightevalTaskConfig(
     evaluation_splits=["test"],
     few_shots_split=None,
     few_shots_select=None,
-    metric=[Metrics.loglikelihood_acc],
+    metrics=[Metrics.loglikelihood_acc],
     version=0,
 )
 

--- a/community_tasks/serbian_eval.py
+++ b/community_tasks/serbian_eval.py
@@ -247,7 +247,7 @@ def create_task_config(
     prompt_function,
     hf_repo: str,
     hf_subset: str,
-    metric: List,
+    metrics: List,
     evaluation_splits: List[str] = ["test"],
     suite: List[str] = ["community"],
     hf_avail_splits: List[str] = ["test", "validation"],
@@ -262,7 +262,7 @@ def create_task_config(
         prompt_function: The function to generate task prompts.
         hf_repo: Hugging Face repository.
         hf_subset: Subset of the dataset.
-        metric: The metric(s) to use for the task.
+        metrics: The metrics to use for the task.
         evaluation_splits: The evaluation splits to use (default is "test").
         suite: The suite of tasks.
         hf_avail_splits: Available splits (default is "test", "validation").
@@ -281,7 +281,7 @@ def create_task_config(
         evaluation_splits=evaluation_splits,
         few_shots_split=few_shots_split,
         few_shots_select="sequential",
-        metric=metric,
+        metrics=metrics,
         generation_size=generation_size,
         # Since we use trust_dataset, we have to be careful about what is inside the dataset
         # script. We thus lock the revision to ensure that the script doesn't change
@@ -300,7 +300,7 @@ arc_easy = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.ARC_EASY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 arc_challenge = create_task_config(
@@ -308,7 +308,7 @@ arc_challenge = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.ARC_CHALLENGE.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 # ============================================
@@ -320,14 +320,14 @@ hellaswag = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.HELLASWAG.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 piqa = create_task_config(
     task_name="serbian_evals:piqa",
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.PIQA.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 winogrande = create_task_config(
@@ -335,7 +335,7 @@ winogrande = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.WINOGRANDE.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 # ============================================
@@ -347,7 +347,7 @@ oz_eval = create_task_config(
     prompt_function=prompt_fn_oz_eval_task,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.OZ_EVAL.value,
-    metric=[Metrics.loglikelihood_acc],
+    metrics=[Metrics.loglikelihood_acc],
 )
 
 # ============================================
@@ -359,7 +359,7 @@ mmlu_anatomy = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_ANATOMY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_astronomy = create_task_config(
@@ -367,7 +367,7 @@ mmlu_astronomy = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_ASTRONOMY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_business_ethics = create_task_config(
@@ -375,7 +375,7 @@ mmlu_business_ethics = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_BUSINESS_ETHICS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_clinical_knowledge = create_task_config(
@@ -383,7 +383,7 @@ mmlu_clinical_knowledge = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_CLINICAL_KNOWLEDGE.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_miscellaneous = create_task_config(
@@ -391,7 +391,7 @@ mmlu_miscellaneous = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_MISCELLANEOUS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_electrical_engineering = create_task_config(
@@ -399,7 +399,7 @@ mmlu_electrical_engineering = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_ELECTRONIC_ENGINEERING.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 # ============================================
@@ -411,7 +411,7 @@ mmlu_all = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_SERBIAN_ALL.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 # ============================================
@@ -423,7 +423,7 @@ mmlu_marketing = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_MARKETING.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_management = create_task_config(
@@ -431,7 +431,7 @@ mmlu_management = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_MANAGEMENT.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 # ============================================
@@ -443,7 +443,7 @@ mmlu_college_biology = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_COLLEGE_BIOLOGY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_college_chemistry = create_task_config(
@@ -451,7 +451,7 @@ mmlu_college_chemistry = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_COLLEGE_CHEMISTRY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_college_computer_science = create_task_config(
@@ -459,7 +459,7 @@ mmlu_college_computer_science = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_COLLEGE_COMPUTER_SCIENCE.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_college_mathematics = create_task_config(
@@ -467,7 +467,7 @@ mmlu_college_mathematics = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_COLLEGE_MATHEMATICS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_college_medicine = create_task_config(
@@ -475,7 +475,7 @@ mmlu_college_medicine = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_COLLEGE_MEDICINE.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_college_physics = create_task_config(
@@ -483,7 +483,7 @@ mmlu_college_physics = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_COLLEGE_PHYSICS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_computer_security = create_task_config(
@@ -491,7 +491,7 @@ mmlu_computer_security = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_COLLEGE_COMPUTER_SECURITY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 # ============================================
@@ -503,7 +503,7 @@ mmlu_moral_disputes = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_MORAL_DISPUTES.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_moral_scenarios = create_task_config(
@@ -511,7 +511,7 @@ mmlu_moral_scenarios = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_MORAL_SCENARIOS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_philosophy = create_task_config(
@@ -519,7 +519,7 @@ mmlu_philosophy = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_PHILOSOPHY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_world_religions = create_task_config(
@@ -527,7 +527,7 @@ mmlu_world_religions = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_WORLD_RELIGIONS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 # ============================================
@@ -539,7 +539,7 @@ mmlu_high_school_biology = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_HIGH_SCHOOL_BIOLOGY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_high_school_chemistry = create_task_config(
@@ -547,7 +547,7 @@ mmlu_high_school_chemistry = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_HIGH_SCHOOL_CHEMISTRY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_high_school_computer_science = create_task_config(
@@ -555,7 +555,7 @@ mmlu_high_school_computer_science = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_HIGH_SCHOOL_COMPUTER_SCIENCE.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_high_school_european_history = create_task_config(
@@ -563,7 +563,7 @@ mmlu_high_school_european_history = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_HIGH_SCHOOL_EURO_HISTORY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_high_school_geography = create_task_config(
@@ -571,7 +571,7 @@ mmlu_high_school_geography = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_HIGH_SCHOOL_GEOGRAPHY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_high_school_mathematics = create_task_config(
@@ -579,7 +579,7 @@ mmlu_high_school_mathematics = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_HIGH_SCHOOL_MATHEMATICS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_high_school_microeconomics = create_task_config(
@@ -587,7 +587,7 @@ mmlu_high_school_microeconomics = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_HIGH_SCHOOL_MICROECONOMICS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_high_school_physics = create_task_config(
@@ -595,7 +595,7 @@ mmlu_high_school_physics = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_HIGH_SCHOOL_PHYSICS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_high_school_psychology = create_task_config(
@@ -603,7 +603,7 @@ mmlu_high_school_psychology = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_HIGH_SCHOOL_PSYCHOLOGY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_high_school_statistics = create_task_config(
@@ -611,7 +611,7 @@ mmlu_high_school_statistics = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_HIGH_SCHOOL_STATISTICS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_high_school_world_history = create_task_config(
@@ -619,7 +619,7 @@ mmlu_high_school_world_history = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_HIGH_SCHOOL_WORLD_HISTORY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 # ============================================
@@ -631,7 +631,7 @@ mmlu_abstract_algebra = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_ABSTRACT_ALGEBRA.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_elementary_mathematics = create_task_config(
@@ -639,7 +639,7 @@ mmlu_elementary_mathematics = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_ELEMENTARY_MATHEMATICS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_formal_logic = create_task_config(
@@ -647,7 +647,7 @@ mmlu_formal_logic = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_FORMAL_LOGIC.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_conceptual_physics = create_task_config(
@@ -655,7 +655,7 @@ mmlu_conceptual_physics = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_CONCEPTUAL_PHYSICS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_econometrics = create_task_config(
@@ -663,7 +663,7 @@ mmlu_econometrics = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_ECONOMETRICS.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_machine_learning = create_task_config(
@@ -671,7 +671,7 @@ mmlu_machine_learning = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_MACHINE_LEARNING.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 # ============================================
@@ -683,7 +683,7 @@ mmlu_global_facts = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_GLOBAL_FACT.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_logical_fallacies = create_task_config(
@@ -691,7 +691,7 @@ mmlu_logical_fallacies = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_LOGICAL_FALLACIES.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_sociology = create_task_config(
@@ -699,7 +699,7 @@ mmlu_sociology = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_SOCIOLOGY.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 mmlu_human_aging = create_task_config(
@@ -707,7 +707,7 @@ mmlu_human_aging = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.MMLU_HUMAN_AGING.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 # ============================================
@@ -719,7 +719,7 @@ boolq = create_task_config(
     prompt_function=boolq_serbian,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.BOOLQ.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 openbook_qa = create_task_config(
@@ -727,7 +727,7 @@ openbook_qa = create_task_config(
     prompt_function=serbian_eval_prompt,
     hf_repo=HFSubsets.HF_BASE_REPO.value,
     hf_subset=HFSubsets.OPENBOOK.value,
-    metric=[Metrics.loglikelihood_acc_norm],
+    metrics=[Metrics.loglikelihood_acc_norm],
 )
 
 

--- a/community_tasks/turkic_evals.py
+++ b/community_tasks/turkic_evals.py
@@ -128,7 +128,7 @@ class CustomTUMLUTask(LightevalTaskConfig):
             hf_subset=hf_subset,
             prompt_function=partial(tumlu_pfn, language=hf_subset),
             hf_repo="jafarisbarov/TUMLU-mini",
-            metric=[Metrics.loglikelihood_acc_norm],
+            metrics=[Metrics.loglikelihood_acc_norm],
             hf_avail_splits=["test", "dev"],
             evaluation_splits=["test"],
             few_shots_split=["dev"],

--- a/community_tasks/turkic_evals.py
+++ b/community_tasks/turkic_evals.py
@@ -44,7 +44,6 @@ from typing import Any, Dict, List, Optional, Union
 
 from lighteval.metrics.llm_as_judge import JudgeLM
 from lighteval.metrics.metrics import Metric, MetricCategory, Metrics
-from lighteval.metrics.utils.metric_utils import MetricUseCase
 from lighteval.tasks.default_prompts import LETTER_INDICES
 from lighteval.tasks.lighteval_task import LightevalTaskConfig
 from lighteval.tasks.requests import Doc

--- a/src/lighteval/main_tasks.py
+++ b/src/lighteval/main_tasks.py
@@ -70,7 +70,7 @@ def list(
     suites: Annotated[
         Optional[str],
         Option(
-            help="Comma-separated list of suites to display (e.g., 'helm,harness'). If not specified, shows core suites only."
+            help="Comma-separated list of suites to display (e.g., 'helm,harness'). Use 'all' for all suites. If not specified, shows core suites only."
         ),
     ] = None,
 ):

--- a/src/lighteval/main_tasks.py
+++ b/src/lighteval/main_tasks.py
@@ -45,13 +45,13 @@ def inspect(
 
     from rich import print
 
-    from lighteval.tasks.registry import Registry
+    from lighteval.tasks.registry import Registry, taskinfo_selector
 
     registry = Registry(custom_tasks=custom_tasks)
 
     # Loading task
-    task_configs = registry.get_tasks_configs(tasks)
-    task_dict = registry.get_tasks_from_configs(task_configs)
+    task_names_list, _ = taskinfo_selector(tasks, task_registry=registry)
+    task_dict = registry.get_task_dict(task_names_list)
     for name, task in task_dict.items():
         print("-" * 10, name, "-" * 10)
         if show_config:
@@ -65,14 +65,22 @@ def inspect(
 
 
 @app.command()
-def list(custom_tasks: Annotated[Optional[str], Option(help="Path to a file with custom tasks")] = None):
+def list(
+    custom_tasks: Annotated[Optional[str], Option(help="Path to a file with custom tasks")] = None,
+    suites: Annotated[
+        Optional[str],
+        Option(
+            help="Comma-separated list of suites to display (e.g., 'helm,harness'). If not specified, shows core suites only."
+        ),
+    ] = None,
+):
     """
     List all tasks
     """
     from lighteval.tasks.registry import Registry
 
     registry = Registry(custom_tasks=custom_tasks)
-    registry.print_all_tasks()
+    registry.print_all_tasks(suites=suites)
 
 
 @app.command()

--- a/src/lighteval/tasks/registry.py
+++ b/src/lighteval/tasks/registry.py
@@ -171,7 +171,9 @@ class Registry:
 
 
         Returns:
-            dict[str, list[dict]]: A dictionary mapping each task name to a list of tuples representing the few_shot and truncate_few_shots values.
+            tuple[list[str], dict[str, list[tuple[int, bool]]]]: A tuple containing:
+                - A sorted list of unique task names in the format "suite|task".
+                - A dictionary mapping each task name to a list of tuples representing the few_shot and truncate_few_shots values.
         """
         few_shot_dict = collections.defaultdict(list)
 

--- a/src/lighteval/tasks/registry.py
+++ b/src/lighteval/tasks/registry.py
@@ -349,6 +349,7 @@ class Registry:
 
         Args:
             suites: Comma-separated list of suites to display. If None, shows core suites only.
+                   Use 'all' to show all available suites (core + optional).
                    Special handling for 'multilingual' suite with dependency checking.
         """
         # Parse requested suites
@@ -356,6 +357,10 @@ class Registry:
             requested_suites = CORE_SUITES.copy()
         else:
             requested_suites = [s.strip() for s in suites.split(",")]
+
+            # Handle 'all' special case
+            if "all" in requested_suites:
+                requested_suites = DEFAULT_SUITES.copy()
 
             # Check for multilingual dependencies if requested
             if "multilingual" in requested_suites:

--- a/src/lighteval/tasks/registry.py
+++ b/src/lighteval/tasks/registry.py
@@ -25,6 +25,7 @@ import copy
 import importlib
 import logging
 import os
+import sys
 from functools import lru_cache
 from itertools import groupby
 from pathlib import Path
@@ -38,6 +39,41 @@ from lighteval.tasks.lighteval_task import LightevalTask, LightevalTaskConfig
 from lighteval.utils.imports import CANNOT_USE_EXTENDED_TASKS_MSG, can_load_extended_tasks
 
 
+# Import community tasks
+AVAILABLE_COMMUNITY_TASKS_MODULES = []
+
+
+def load_community_tasks():
+    """Dynamically load community tasks, handling errors gracefully."""
+    modules = []
+    try:
+        # Community tasks are in the lighteval directory, not under src
+        community_path = Path(__file__).parent.parent.parent.parent / "community_tasks"
+        if not community_path.exists():
+            return modules
+
+        # Ensure the parent directory is on sys.path so we can import `community_tasks.*`
+        parent_dir = str(community_path.parent)
+        if parent_dir not in sys.path:
+            sys.path.insert(0, parent_dir)
+
+        # List all python files in community_tasks
+        community_files = [p.stem for p in community_path.glob("*.py") if not p.name.startswith("_")]
+
+        for module_name in community_files:
+            try:
+                module = importlib.import_module(f"community_tasks.{module_name}")
+                if hasattr(module, "TASKS_TABLE"):
+                    modules.append(module)
+                    logger.info(f"Successfully loaded community tasks from {module_name}")
+            except Exception as e:
+                logger.warning(f"Failed to load community tasks from {module_name}: {e}")
+    except Exception as e:
+        logger.warning(f"Error loading community tasks directory: {e}")
+
+    return modules
+
+
 logger = logging.getLogger(__name__)
 
 # Helm, Bigbench, Harness are implementations following an evaluation suite setup
@@ -46,7 +82,9 @@ logger = logging.getLogger(__name__)
 # Community are for community added evaluations
 # Extended are for evaluations with custom logic
 # Custom is for all the experiments you might want to do!
-DEFAULT_SUITES = [
+
+# Core suites - always available without extra dependencies
+CORE_SUITES = [
     "helm",
     "bigbench",
     "harness",
@@ -55,9 +93,16 @@ DEFAULT_SUITES = [
     "original",
     "extended",
     "custom",
-    "community",
     "test",
 ]
+
+# Optional suites - may require extra dependencies
+OPTIONAL_SUITES = [
+    "community",
+    "multilingual",
+]
+
+DEFAULT_SUITES = CORE_SUITES + OPTIONAL_SUITES
 
 TRUNCATE_FEW_SHOTS_DEFAULTS = True
 
@@ -136,6 +181,24 @@ class Registry:
                 custom_tasks_module.append(extended_task_module)
         else:
             logger.warning(CANNOT_USE_EXTENDED_TASKS_MSG)
+
+        # Load community tasks
+        community_modules = load_community_tasks()
+        for community_task_module in community_modules:
+            custom_tasks_module.append(community_task_module)
+
+        # Load multilingual tasks
+        MULTILINGUAL_TASKS_AVAILABLE = False
+        multilingual_tasks = None
+        try:
+            import lighteval.tasks.multilingual.tasks as multilingual_tasks
+
+            MULTILINGUAL_TASKS_AVAILABLE = True
+        except ImportError as e:
+            logger.warning(f"Could not load multilingual tasks: {e}. You may need to install additional dependencies.")
+
+        if MULTILINGUAL_TASKS_AVAILABLE and multilingual_tasks is not None:
+            custom_tasks_module.append(multilingual_tasks)
 
         for module in custom_tasks_module:
             custom_task_configs.extend(module.TASKS_TABLE)
@@ -280,18 +343,61 @@ class Registry:
         # Then it must be a single task
         return [task_definition]
 
-    def print_all_tasks(self):
+    def print_all_tasks(self, suites: str | None = None):
         """
         Print all the tasks in the task registry.
+
+        Args:
+            suites: Comma-separated list of suites to display. If None, shows core suites only.
+                   Special handling for 'multilingual' suite with dependency checking.
         """
-        tasks_names = list(self.task_registry.keys())
+        # Parse requested suites
+        if suites is None:
+            requested_suites = CORE_SUITES.copy()
+        else:
+            requested_suites = [s.strip() for s in suites.split(",")]
+
+            # Check for multilingual dependencies if requested
+            if "multilingual" in requested_suites:
+                import importlib.util
+
+                if importlib.util.find_spec("langcodes") is None:
+                    logger.warning(
+                        "Multilingual tasks require additional dependencies (langcodes). "
+                        "Install them with: pip install langcodes"
+                    )
+                    requested_suites.remove("multilingual")
+
+        # Get all tasks and filter by requested suites
+        all_tasks = list(self.task_registry.keys())
+        tasks_names = [task for task in all_tasks if task.split("|")[0] in requested_suites]
+
+        # Ensure all requested suites are present (even if empty)
+        suites_in_registry = {name.split("|")[0] for name in tasks_names}
+        for suite in requested_suites:
+            if suite not in suites_in_registry:
+                # We add a dummy task to make sure the suite is printed
+                tasks_names.append(f"{suite}|")
+
         tasks_names.sort()
+
+        print(f"Displaying tasks for suites: {', '.join(requested_suites)}")
+        print("=" * 60)
+
         for suite, g in groupby(tasks_names, lambda x: x.split("|")[0]):
-            tasks_names = list(g)
-            tasks_names.sort()
+            tasks_in_suite = [name for name in g if name.split("|")[1]]  # Filter out dummy tasks
+            tasks_in_suite.sort()
+
             print(f"\n- {suite}:")
-            for task_name in tasks_names:
-                print(f"  - {task_name}")
+            if not tasks_in_suite:
+                print("  (no tasks in this suite)")
+            else:
+                for task_name in tasks_in_suite:
+                    print(f"  - {task_name}")
+
+        # Print summary
+        total_tasks = len([t for t in tasks_names if t.split("|")[1]])
+        print(f"\nTotal tasks displayed: {total_tasks}")
 
     @staticmethod
     def create_custom_tasks_module(custom_tasks: str | Path | ModuleType) -> ModuleType:


### PR DESCRIPTION
feat(tasks): Enhance task discovery and display. Bug mentioned here: #903 

This PR improves the task registry to ensure all available task suites, including community, custom, test suites ... are correctly discovered and displayed in the `lighteval tasks list` command.

The key changes include:

- **Dynamic Community Task Loading:** the new function (`load_community_tasks`) is to dynamically scan the `community_tasks` directory and load any valid task modules. This process is resilient, as it gracefully handles and logs errors for any malformed task files without interrupting the loading of others.

- **Lazy Loading for Multilingual Tasks:** The import for multilingual tasks is now deferred until the task registry is accessed. This prevents crashes when optional dependencies (like `langcodes`) are not installed and instead logs a helpful warning.

- **Comprehensive Suite Display:** The `print_all_tasks` function has been updated to guarantee that all `DEFAULT_SUITES` (including `custom` and `test`) are always visible in the output, even if they contain no tasks. A "(no tasks in this suite)" message is now shown for empty suites to improve clarity.

These changes provide a more robust and complete discovery mechanism, giving users a reliable view of all available tasks in `lighteval`.

Before these changes, the command `lighteval tasks list` used to return about **1500** lines (tasks).
After these changes, the command `lighteval tasks list` now returns more than **74200** lines (tasks).