### PR TITLE
Adds the option to override the chat template

### DIFF
--- a/src/lighteval/models/sglang/sglang_model.py
+++ b/src/lighteval/models/sglang/sglang_model.py
@@ -94,6 +94,9 @@ class SGLangModelConfig(ModelConfig):
             Fraction of GPU memory to use for static allocation. Defaults to 0.8.
         chunked_prefill_size (PositiveInt):
             Size of chunks for prefill operations. Defaults to 4096.
+        override_chat_template (bool):
+            If True, we force the model to use a chat template. If alse, we prevent the model from using
+            a chat template. If None, we use the default (true if present in the tokenizer, false otherwise)
 
     Example:
         ```python
@@ -126,6 +129,7 @@ class SGLangModelConfig(ModelConfig):
     attention_backend: str | None = None
     mem_fraction_static: PositiveFloat = 0.8
     chunked_prefill_size: PositiveInt = 4096
+    override_chat_template: bool = None
 
 
 class SGLangModel(LightevalModel):
@@ -135,7 +139,9 @@ class SGLangModel(LightevalModel):
     ):
         """Initializes an SGLang model."""
         self.config = config
-        self.use_chat_template = uses_chat_template(model_name=self.config.model_name)
+        self.use_chat_template = uses_chat_template(
+            model_name=self.config.model_name, override_chat_template=config.override_chat_template
+        )
         self.data_parallel_size = config.dp_size
         self.tensor_parallel_size = config.tp_size
         self._add_special_tokens = config.add_special_tokens

--- a/src/lighteval/models/utils.py
+++ b/src/lighteval/models/utils.py
@@ -109,7 +109,9 @@ def batched(iterable, n):
         yield batch
 
 
-def uses_chat_template(model_name: str = None, tokenizer: AutoTokenizer = None) -> bool:
+def uses_chat_template(
+    model_name: str = None, tokenizer: AutoTokenizer = None, override_chat_template: bool = None
+) -> bool:
     """Returns a boolean depending on whether the Transformers AutoTokenizer contains
     a chat template or not
 
@@ -119,6 +121,8 @@ def uses_chat_template(model_name: str = None, tokenizer: AutoTokenizer = None) 
     Returns:
         bool: True if Tokenizer config contains a chat template, False otherwise
     """
+    if override_chat_template is not None:
+        return override_chat_template
     if model_name is None and tokenizer is None:
         raise Exception("`uses_chat_template` requires either a tokenizer or model name as input")
     try:

--- a/src/lighteval/models/vllm/vllm_model.py
+++ b/src/lighteval/models/vllm/vllm_model.py
@@ -124,6 +124,9 @@ class VLLMModelConfig(ModelConfig):
             Subfolder within the model repository. Defaults to None.
         is_async (bool):
             Whether to use the async version of VLLM. Defaults to False.
+        override_chat_template (bool):
+            If True, we force the model to use a chat template. If alse, we prevent the model from using
+            a chat template. If None, we use the default (true if present in the tokenizer, false otherwise)
 
     Example:
         ```python
@@ -164,6 +167,7 @@ class VLLMModelConfig(ModelConfig):
     max_num_batched_tokens: PositiveInt = 2048  # maximum number of tokens per batch
     subfolder: str | None = None
     is_async: bool = False  # Whether to use the async version or sync version of the model
+    override_chat_template: bool = None
 
 
 class VLLMModel(LightevalModel):
@@ -173,7 +177,9 @@ class VLLMModel(LightevalModel):
     ):
         """Initializes a HuggingFace `AutoModel` and `AutoTokenizer` for evaluation."""
         self.config = config
-        self.use_chat_template = uses_chat_template(model_name=config.model_name)
+        self.use_chat_template = uses_chat_template(
+            model_name=config.model_name, override_chat_template=config.override_chat_template
+        )
         self.data_parallel_size = config.data_parallel_size
         self.tensor_parallel_size = config.tensor_parallel_size
         self._add_special_tokens = config.add_special_tokens if config.add_special_tokens is not None else False

--- a/tests/models/test_model_utils.py
+++ b/tests/models/test_model_utils.py
@@ -42,3 +42,19 @@ class TestUseChatTemplate(unittest.TestCase):
 
         result = uses_chat_template(tokenizer=mock_tokenizer)
         self.assertFalse(result)
+
+    def test_uses_chat_template_with_chat_template_present_override(self):
+        """Test that uses_chat_template returns True when tokenizer has a chat template."""
+        mock_tokenizer = Mock()
+        mock_tokenizer.chat_template = "{% for message in messages %}..."
+
+        result = uses_chat_template(tokenizer=mock_tokenizer, override_chat_template=False)
+        self.asserFalse(result)
+
+    def test_uses_chat_template_with_no_chat_template_override(self):
+        """Test that uses_chat_template returns False when tokenizer has no chat template."""
+        mock_tokenizer = Mock()
+        mock_tokenizer.chat_template = None
+
+        result = uses_chat_template(tokenizer=mock_tokenizer, override_chat_template=True)
+        self.assertTrue(result)

--- a/tests/models/test_model_utils.py
+++ b/tests/models/test_model_utils.py
@@ -49,7 +49,7 @@ class TestUseChatTemplate(unittest.TestCase):
         mock_tokenizer.chat_template = "{% for message in messages %}..."
 
         result = uses_chat_template(tokenizer=mock_tokenizer, override_chat_template=False)
-        self.asserFalse(result)
+        self.assertFalse(result)
 
     def test_uses_chat_template_with_no_chat_template_override(self):
         """Test that uses_chat_template returns False when tokenizer has no chat template."""


### PR DESCRIPTION
New behavior for the chat template is to be detected by default (true if the tokenizer has a chat template, false otherwise) - we now allow the user to override this.