### PR TITLE
Use lower bound for httpx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "protobuf",
     "pycountry",
     "fsspec>=2023.12.2",
-    "httpx == 0.27.2",
+    "httpx>=0.27.2",
     "latex2sympy2_extended==1.0.6",
 ]
 


### PR DESCRIPTION
Pinning `httpx` produces dependency conflicts in other libs, so this PR proposes to use a lower bound instead. I am not sure what the impact of this is on the code, so will leave it to the maintainers to decide if this is a good idea or not :)