### PR TITLE
Save reasoning_content from litellm as details

### DIFF
--- a/src/lighteval/models/endpoints/litellm_model.py
+++ b/src/lighteval/models/endpoints/litellm_model.py
@@ -294,10 +294,14 @@ class LiteLLMClient(LightevalModel):
 
             for response, context in zip(responses, contexts):
                 result: list[str] = [choice.message.content for choice in response.choices]
+                reasonings: list[str | None] = [
+                    getattr(choice.message, "reasoning_content", None) for choice in response.choices
+                ]
 
                 cur_response = ModelResponse(
                     # In empty responses, the model should return an empty string instead of None
                     text=result if result[0] else [""],
+                    reasonings=reasonings,
                     input=context,
                 )
                 results.append(cur_response)

--- a/src/lighteval/models/model_output.py
+++ b/src/lighteval/models/model_output.py
@@ -127,6 +127,7 @@ class ModelResponse:
     text: list[str] = field(default_factory=list)  # The text of the response
     output_tokens: list[list[int]] = field(default_factory=list)  # Model generations
     text_post_processed: list[str] | None = None  # The text of the response postprocessed
+    reasonings: list[str | None] = field(default_factory=list)  # The reasoning content of the response
 
     # Model logprob outputs
     logprobs: list[float] = field(default_factory=list)  # Log probabilities of the response


### PR DESCRIPTION
Resolves #927 

This PR enables saving `reasoning_content` returned by litellm in the details file.


## How I tested

I'm using vllm==0.9.2 and litellm==1.74.15.post2.
```bash
# Start vLLM server
vllm serve Qwen/Qwen3-1.7B --tensor-parallel-size 2 --trust-remote-code --dtype bfloat16 --gpu-memory-utilization 0.9 --max_model_len 32768 --reasoning-parser qwen3

# Evaluate via litellm entry point
lighteval endpoint litellm "model_name=hosted_vllm/Qwen/Qwen3-1.7B,base_url=http://0.0.0.0:8000/v1,api_key=\"\",generation_parameters={temperature:1,max_new_tokens:16000}" "lighteval|math_500|0|0" --save-details

# Check the content of the details file (only first example)
echo results/details/hosted_vllm/Qwen/Qwen3-1.7B/2025-08-19T22-27-32.231875/details_lighteval\|math_500\|0_2025-08-19T22-27-32.231875.parquet | python -c "import pandas as pd; print(pd.read_parquet(input().strip()).head(1).to_json())" | jq > reasonings_sample.json
```

"reasonings" is added under "model_response". Since it is too large to paste the content here, I attached the json file.
[reasonings_sample.json](https://github.com/user-attachments/files/21856827/reasonings_sample.json)
