### PR TITLE
Added `backend_options` parameter to llm judges.

### DIFF
--- a/src/lighteval/metrics/metrics_sample.py
+++ b/src/lighteval/metrics/metrics_sample.py
@@ -947,6 +947,7 @@ class JudgeLLM(SampleLevelComputation):
         url: str | None = None,
         hf_provider: str | None = None,
         max_tokens: int | None = None,
+        backend_options: dict | None = None,
     ) -> None:
         logger.debug(f"Initializing JudgeLLM with backend: {judge_backend}, model: {judge_model_name}")
 
@@ -993,6 +994,7 @@ class JudgeLLM(SampleLevelComputation):
             url=url,
             hf_provider=hf_provider,
             max_tokens=max_tokens,
+            backend_options=backend_options,
         )
 
     def compute(self, responses: list[ModelResponse], docs: list[Doc], **kwargs) -> list:

--- a/src/lighteval/metrics/utils/llm_as_judge.py
+++ b/src/lighteval/metrics/utils/llm_as_judge.py
@@ -26,7 +26,7 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Callable, Dict, Literal, Optional
+from typing import Callable, Literal, Optional
 
 from huggingface_hub import AsyncInferenceClient, InferenceTimeoutError
 from pydantic import BaseModel
@@ -36,6 +36,7 @@ from tqdm.asyncio import tqdm_asyncio
 
 from lighteval.utils.imports import is_litellm_available, is_openai_available, is_vllm_available
 from lighteval.utils.utils import as_list
+
 
 logging.getLogger("openai").setLevel(logging.ERROR)
 logging.getLogger("httpx").setLevel(logging.ERROR)

--- a/src/lighteval/metrics/utils/llm_as_judge.py
+++ b/src/lighteval/metrics/utils/llm_as_judge.py
@@ -37,7 +37,6 @@ from tqdm.asyncio import tqdm_asyncio
 from lighteval.utils.imports import is_litellm_available, is_openai_available, is_vllm_available
 from lighteval.utils.utils import as_list
 
-
 logging.getLogger("openai").setLevel(logging.ERROR)
 logging.getLogger("httpx").setLevel(logging.ERROR)
 logger = logging.getLogger(__name__)
@@ -67,38 +66,19 @@ class LitellmBackendOptions:
 class JudgeLM:
     """A class representing a judge for evaluating answers using either the chosen backend.
 
-    Args:
+    Attributes:
         model (str): The name of the model.
         templates (Callable): A function taking into account the question, options, answer, and gold and returning the judge prompt.
         process_judge_response (Callable): A function for processing the judge's response.
         judge_backend (Literal["litellm", "openai", "transformers", "tgi", "vllm", "inference-providers"]): The backend for the judge.
         url (str | None): The URL for the OpenAI API.
         api_key (str | None): The API key for the OpenAI API (either OpenAI or HF key).
-        max_tokens (int): The maximum number of tokens to generate.
-        response_format (BaseModel | None): The format of the response from the API, used for the OpenAI and TGI backend. If not set,
-            no structured outputs will be generated, just text.
-        hf_provider (Optional[Literal["black-forest-labs", "cerebras", "cohere", "fal-ai", "fireworks-ai",
-            "inference-providers", "hyperbolic", "nebius", "novita", "openai", "replicate", "sambanova", "together"]]):
+        max_tokens (int): The maximum number of tokens to generate. Defaults to 512.
+        response_format (BaseModel | None): The format of the response from the API, used for the OpenAI and TGI backend.
+        hf_provider (Literal["black-forest-labs", "cerebras", "cohere", "fal-ai", "fireworks-ai",
+            "inference-providers", "hyperbolic", "nebius", "novita", "openai", "replicate", "sambanova", "together"] | None):
             The HuggingFace provider when using the inference-providers backend.
-        backend_options (Optional[Dict]): Options for the backend. Currently only supported for litellm.
-
-    Attributes:
-        model (str): The name of the model.
-        template (Callable): A function taking into account the question, options, answer, and gold and returning the judge prompt.
-        API_MAX_RETRY (int): The maximum number of retries for the API.
-        API_RETRY_SLEEP (int): The time to sleep between retries.
-        client (OpenAI | None): The OpenAI client.
-        pipe (LLM | AutoModel | None): The Transformers or vllm pipeline.
-        process_judge_response (Callable): A function for processing the judge's response.
-        url (str | None): The URL for the OpenAI API.
-        api_key (str | None): The API key for the OpenAI API (either OpenAI or HF key).
-        backend (Literal["litellm", "openai", "transformers", "tgi", "vllm", "inference-providers"]): The backend for the judge.
-        max_tokens (int): The maximum number of tokens to generate.
-        response_format (BaseModel | dict): The format of the response from the API, used for the OpenAI and TGI backend.
-        hf_provider (Optional[Literal["black-forest-labs", "cerebras", "cohere", "fal-ai", "fireworks-ai",
-            "inference-providers", "hyperbolic", "nebius", "novita", "openai", "replicate", "sambanova", "together"]]):
-            The HuggingFace provider when using the inference-providers backend.
-        backend_options (Union[LitellmBackendOptions, Dict]): Options for the backend. Currently only supported for litellm.
+        backend_options (dict | None): Options for the backend. Currently only supported for litellm.
 
     Methods:
         evaluate_answer: Evaluates an answer using the OpenAI API or Transformers library.
@@ -135,7 +115,7 @@ class JudgeLM:
                 "together",
             ]
         ] = None,
-        backend_options: Optional[Dict] = None,
+        backend_options: dict | None = None,
     ):
         self.model = model
         self.template = templates
@@ -155,7 +135,7 @@ class JudgeLM:
 
         self.response_format = response_format if not None else DEFAULT_FORMAT
 
-        self.backend_options = backend_options if backend_options else {}
+        self.backend_options = backend_options or {}
 
         # Override backend options dictionary with the corresponding dataclass to ensure all specified options are valid
         if judge_backend == "litellm":


### PR DESCRIPTION
As part of a community task I have been collaborating on, I've encountered various challenges with the litellm judge backend. The challenges were (#962):

- Judge outputs are currently not cached. If the evaluation script fails, the responses from the judge need to be regenerated, leading to higher evaluation costs.
- Not all inference providers support the same set of parameters when generating chat completions.
- The maximum number of generated tokens is currently hardcoded to 512 in the litellm backend
- Currently, 100 concurrent requests are performed, potentially leading to the client running into rate limits. 

These changes are solved in this PR in the following way:

The `JudgeLM` and `JudgeLLM` constructors now accept a `backend_options` parameter (dict). In case of the litellm backend, this is then converted to a new dataclass `LitellmBackendOptions`, which allows to specify whether to use caching or not, how many concurrent requests should be performed, and whether to increase the number of output tokens in case of reasoning models or not.

Additionally, the litellm backend will now by default ignore chat completion arguments that are not supported by the currently used inference provider. The `max_tokens` parameter is now respected by the litellm backend instead of using a hardcoded value.

I'm looking forward to discussing the current solution or potential alternatives!