### PR TITLE
Fix AvgAtK num_samples method

### DIFF
--- a/src/lighteval/metrics/metrics_sample.py
+++ b/src/lighteval/metrics/metrics_sample.py
@@ -1208,9 +1208,9 @@ class AvgAtK(SamplingMetric, SampleLevelComputation):
         """Get the number of samples for this metric.
 
         Returns:
-            int: The number of samples (n if specified, otherwise k)
+            int: The number of samples
         """
-        return self.n if self.n is not None else self.k
+        return self.k
 
 
 class MajAtK(SamplingMetric, SampleLevelComputation):


### PR DESCRIPTION
Attempted to run `lighteval tasks inspect "helm|summarization:xsum|0"` and got `AttributeError: 'AvgAtK' object has no attribute 'n'` for the `.num_samples()` method. I can't see a `n` attribute used elsewhere in the metric and as far as I can see, it looks like `self.k` is sufficient for this.