### PR TITLE
Fix deberta overflow error

### DIFF
--- a/src/lighteval/metrics/imports/bert_scorer.py
+++ b/src/lighteval/metrics/imports/bert_scorer.py
@@ -44,7 +44,7 @@ def validate_tokenizer_length(tokenizer: AutoTokenizer, override_length: int | N
         logger.warning("Could not read max_model_length attribute for BERTScorer's tokenizer - defaulting to 512.")
         return 512
     else:
-        return tokenizer.max_model_length
+        return tokenizer.model_max_length
 
 
 def padding(arr, pad_token, dtype=torch.long):

--- a/src/lighteval/metrics/imports/bert_scorer.py
+++ b/src/lighteval/metrics/imports/bert_scorer.py
@@ -443,10 +443,9 @@ class BERTScorer:
         if self._model is None:
             logger.info(f"Loading BERTScorer model `{self._model_type}`")
             self._tokenizer = AutoTokenizer.from_pretrained(self._model_type)
-            self._tokenizer.max_model_length = validate_tokenizer_length(
+            self._tokenizer.model_max_length = validate_tokenizer_length(
                 tokenizer=self._tokenizer, override_length=self._tokenizer_len
             )
-
             self._model = AutoModel.from_pretrained(self._model_type)
             self._model.eval()
             self._model.to(self.device)

--- a/src/lighteval/metrics/metrics_sample.py
+++ b/src/lighteval/metrics/metrics_sample.py
@@ -643,7 +643,11 @@ class BertScore(SampleLevelComputation):
             logger.warning("The first metric computation step might be a bit longer as we need to download the model.")
             # We only initialize on first compute
             self.bert_scorer = BERTScorer(
-                model_type="microsoft/deberta-large-mnli", lang="en", rescale_with_baseline=True, num_layers=9
+                model_type="microsoft/deberta-large-mnli",
+                lang="en",
+                rescale_with_baseline=True,
+                num_layers=9,
+                tokenizer_max_len=512,
             )
         golds = as_list(golds)
         predictions = as_list(predictions)


### PR DESCRIPTION
# Description
Running `lighteval vllm "model_name=meta-llama/Llama-3.2-3B-Instruct" "helm|summarization:xsum|0" --max-samples=5` encounters `OverflowError: int too big to convert` when attempting to calculate BERTScore metrics.

This appears to be an issue with the tokenizer configuration file (https://huggingface.co/microsoft/deberta-large-mnli/discussions/1), and so the tokenizer's `max_model_length` attribute defaults to a value of 1e30 (https://github.com/huggingface/transformers/issues/14561). 

# Changes
1. I've added an extra optional argument to the `__init__` method of the BERTScore class, which allows the user to override the tokenizer's `max_model_length` attribute. 
2. In the new function `validate_tokenizer_length()`, the tokenizer's `max_model_length` will be set to the overriding value if set.  If an override value is not set, it will check if the model length is the misconfigured value of 1e30 and, if so, default to 512 with a warning to the user. Otherwise, the original length is used.
3. Added override value of 512 for `deberta-large-mnli`, which is the default BERTScore model.