### PR TITLE
Wrap vllm inputs to compatible with VLLM>=0.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ nanotron = [
   "tensorboardX"
 ]
 tensorboardX = ["tensorboardX"]
-vllm = ["vllm>=0.10.0,<0.10.2", "ray", "more_itertools"]
+vllm = ["vllm>=0.10.0", "ray", "more_itertools"]
 sglang = ["sglang"]
 quality = ["ruff>=v0.11.0","pre-commit"]
 tests = ["pytest>=7.4.0","deepdiff","pip>=25.2"]


### PR DESCRIPTION
I've implemented the code to support VLLM>=0.10.2 as mentioned in issue #1002, so that we can evaluate the newest models with lighteval. 

Please take a look. 
Thank you.