### PR TITLE
not forcing use_logits at True

### DIFF
--- a/src/lighteval/tasks/lighteval_task.py
+++ b/src/lighteval/tasks/lighteval_task.py
@@ -388,7 +388,7 @@ class LightevalTask:
             )
             doc.sampling_methods.extend(self.sampling_methods)
             doc.generation_size = self.generation_size
-            doc.use_logits = True
+            doc.use_logits = doc.use_logits if doc.use_logits is not None else True
             doc.stop_sequences = self.stop_sequence
             doc.num_samples = max(self.num_samples)
             docs.append(doc)


### PR DESCRIPTION
For some reason here `use_logits` is forced to `True` regardless of what the `doc` object says regarding of `use_logits`. 

I think that the intended behavior should be that `doc.use_logits` takes priority here. 