### PR TITLE
Fix set using wrong syntax

### DIFF
--- a/src/lighteval/tasks/tasks/ifbench/instructions.py
+++ b/src/lighteval/tasks/tasks/ifbench/instructions.py
@@ -1133,7 +1133,7 @@ class PronounCountChecker(Instruction):
 
     def check_following(self, value):
         """Checks if the response includes at least {N} pronouns."""
-        pronouns = set(
+        pronouns = {
             "i",
             "me",
             "my",
@@ -1165,7 +1165,7 @@ class PronounCountChecker(Instruction):
             "their",
             "theirs",
             "themselves",
-        )
+        }
         value = value.replace(
             "/", " "
         )  # to correctly count pronoun sets like she/her/hers, a common use case of pronouns


### PR DESCRIPTION
the `check_following` method in `src/lighteval/tasks/tasks/ifbench/instructions.py` is using the wrong syntax for the getting a set out of a list of items

`set(1,2,3)` -> `{1,2,3}`