### PR TITLE
Fix: correct argument order in MajAtN.compute

### DIFF
--- a/src/lighteval/metrics/metrics_sample.py
+++ b/src/lighteval/metrics/metrics_sample.py
@@ -1255,7 +1255,7 @@ class MajAtN(SamplingMetric, SampleLevelComputation):
         new_model_response = ModelResponse(
             text=[majority_prediction],
         )
-        return self.compute_score(new_model_response, new_doc)
+        return self.compute_score(new_doc, new_model_response)
 
     def num_samples(self):
         return self.n


### PR DESCRIPTION
## Description
In `lighteval/src/lighteval/metrics/metrics_sample.py` line 1258, the `MajAtN.compute` method calls:

```python
return self.compute_score(new_model_response, new_doc)
````

However, `compute_score` (e.g., `MultilingualExtractiveMatchMetric.compute`) expects the signature:

```python
def compute(self, doc: Doc, model_response: ModelResponse) -> float
```

As a result, the arguments are swapped, which cause runtime errors.

## To Reproduce

Steps to reproduce the behavior:

1. Install `lighteval` version 0.12.2.
2. Define a metric using `MajAtN` with a subclass of `MultilingualExtractiveMatchMetric`.
3. Call `compute` on a sample `Doc` and `ModelResponse`.
4. Observe a `TypeError` or incorrect metric values due to the argument order mismatch.

## Expected Behavior

`MajAtN.compute` should pass arguments in the correct order:

```python
return self.compute_score(new_doc, new_model_response)
```

so that `compute_score(doc, model_response)` executes correctly.
