### PR TITLE
Update LiteLLM configuration for hosted_vllm provider

### DIFF
--- a/docs/source/use-litellm-as-backend.mdx
+++ b/docs/source/use-litellm-as-backend.mdx
@@ -63,8 +63,8 @@ vllm serve HuggingFaceH4/zephyr-7b-beta --host 0.0.0.0 --port 8000
 2. Configure LiteLLM to use the local server:
 ```yaml
 model_parameters:
-    provider: "openai"
-    model_name: "HuggingFaceH4/zephyr-7b-beta"
+    provider: "hosted_vllm"
+    model_name: "hosted_vllm/HuggingFaceH4/zephyr-7b-beta"
     base_url: "http://localhost:8000/v1"
     api_key: ""
 ```


### PR DESCRIPTION
even though vllm produces openai compatible endpoint, to make work you have to use provider as hosted_vllm and use a hosted_vllm prefix prior to model name