### PR TITLE
graceful shutdown of vllm async

### DIFF
--- a/src/lighteval/models/vllm/vllm_model.py
+++ b/src/lighteval/models/vllm/vllm_model.py
@@ -544,6 +544,7 @@ class AsyncVLLMModel(VLLMModel):
     is_async = True
 
     def cleanup(self):
+        self.model.shutdown()
         gc.collect()
         destroy_distributed_environment()
         torch.cuda.empty_cache()
@@ -627,7 +628,6 @@ class AsyncVLLMModel(VLLMModel):
         results = await asyncio.gather(*processed_requests)
         return results
 
-    @cached(SamplingMethod.GENERATIVE)
     async def greedy_until(
         self,
         docs: list[Doc],
@@ -661,7 +661,6 @@ class AsyncVLLMModel(VLLMModel):
 
         return results
 
-    @cached(SamplingMethod.LOGPROBS)
     async def loglikelihood(
         self,
         docs: list[Doc],

--- a/src/lighteval/pipeline.py
+++ b/src/lighteval/pipeline.py
@@ -308,6 +308,8 @@ class Pipeline:
                     model_outputs = await self.model.loglikelihood(docs)
                     outputs[sampling_method] = model_outputs
 
+        self.model.cleanup()
+
         return outputs
 
     def _run_model_sync(self):
@@ -327,6 +329,8 @@ class Pipeline:
                     model_outputs = self.model.loglikelihood_rolling(docs)
                     outputs[sampling_method] = model_outputs
 
+        self.model.cleanup()
+
         return outputs
 
     def _run_model(self):
@@ -338,9 +342,6 @@ class Pipeline:
             outputs = asyncio.run(self._run_model_async())
         else:
             outputs = self._run_model_sync()
-
-        # Cleaning up the model before running metrics
-        self.model.cleanup()
 
         return outputs
 


### PR DESCRIPTION
### Summary

This PR introduces a minimal refactoring to ensure that vLLM shuts down gracefully during cleanup. Without this change, users would encounter the following error at the end of an evaluation:

```
RuntimeError: There is no current event loop in thread 'MainThread'.
```

Additionally, I removed the `@cache` decorator, as it was not functioning correctly and resulted in:

```
TypeError: 'coroutine' object is not iterable
```

