### PR TITLE
batched metric was not aggregated properly

### DIFF
--- a/src/lighteval/metrics/__init__.py
+++ b/src/lighteval/metrics/__init__.py
@@ -45,8 +45,8 @@ def apply_metric(responses: list[ModelResponse], docs: list[Doc], metrics: list[
         output = {}
 
         # Add batched metric results for this sample
-        for metric_outputs in batched_outputs:
-            output.update(metric_outputs[i])
+        for metric, metric_outputs in zip(batched_metrics, batched_outputs):
+            output.update({metric.metric_name: metric_outputs[metric.metric_name][i]})
 
         # Add non-batched metric results for this sample
         for metric in non_batched_metrics:


### PR DESCRIPTION

I’m not entirely sure this is the ideal approach, but here’s what I found:

`batched_metrics` returns a structure like:

```python
{
  "metric_name": [1, 2, 3, 4]
}
```

Because of this additional dictionary layer, the aggregation step was throwing an `IndexError`. The issue can be resolved by extracting the metric name and its corresponding batch directly, rather than operating on the dictionary as-is.

