### PR TITLE
[EVAL] Long Horizon Execution

### DIFF
--- a/src/lighteval/tasks/tasks/long_horizon_execution.py
+++ b/src/lighteval/tasks/tasks/long_horizon_execution.py
@@ -1,26 +1,56 @@
 """
-DOCSTRING TO BE IMPLEMENTED
+name:
+Long Horizon Execution
+
+dataset:
+arvindh75/Long-Horizon-Execution
+
+abstract:
+This dataset is a synthetic benchmark designed to measure the pure execution
+capability of LLMs over long horizons. The core task is key-value dictionary addition.
+A fixed, in-context dictionary mapping five-letter English words (keys) to integer values
+is provided in dictionary.json. The model's goal is to maintain a running sum.
+In each turn, it receives one or more keys (defined by the turn complexity, K),
+retrieves their corresponding values from the dictionary, adds them to the running sum, and outputs the new sum.
+The primary metric for evaluation is the task length: the number of steps a model can execute before its accuracy drops below a certain threshold.
+
+languages:
+english
+
+tags:
+agent, llm, benchmark
+
+paper:
+https://arxiv.org/abs/2509.09677
+
+starred:
+true
 """
 
+import re
+
 from inspect_ai.dataset import Sample
-from inspect_ai.solver import generate
+from inspect_ai.scorer import Score, Target, accuracy, scorer, stderr
+from inspect_ai.solver import TaskState, generate
 
+from lighteval.metrics.metrics import Metrics
 from lighteval.tasks.lighteval_task import LightevalTaskConfig
+from lighteval.tasks.requests import Doc
 
 
-def record_to_sample(record):
+def _build_prompt_and_target(record):
+    """
+    Helper function to extract common logic for building prompt and target.
+    Processes the record and returns prompt, target, and metadata.
+
+    Returns:
+        tuple: (prompt: str, target_str: str, metadata: dict)
+    """
     input_keys = record["input"]
     input_values = record["values"]
     expected_output = record["output"]
 
-    MAX_ITEMS = 100  # for truncation, can be adjusted.
-    if len(input_keys) > MAX_ITEMS:
-        input_keys = input_keys[:MAX_ITEMS]
-        input_values = input_values[:MAX_ITEMS]
-        expected_output = expected_output[:MAX_ITEMS]
-
     dictionary = dict(zip(input_keys, input_values))
-
     dict_str = str(dictionary)
     keys_str = str(input_keys)
 
@@ -50,26 +80,97 @@ Your answer:"""
 
     target_str = ",".join(map(str, expected_output))
 
+    metadata = {
+        "input_keys": input_keys,
+        "input_values": input_values,
+        "expected_output": expected_output,
+        "dictionary": dictionary,
+        "num_items": len(input_keys),
+    }
+
+    return prompt, target_str, metadata
+
+
+def long_horizon_execution_prompt_function(line, task_name: str = None):
+    """
+    Prompt function for non-inspect-ai backend.
+    Converts dataset record to Doc object.
+    """
+    prompt, target_str, _ = _build_prompt_and_target(line)
+
+    return Doc(
+        task_name=task_name,
+        query=prompt,
+        choices=[target_str],  # Expected answer as a choice
+        gold_index=0,
+        instruction=prompt,
+    )
+
+
+def record_to_sample(record):
+    """
+    Converts dataset record to inspect-ai Sample object.
+    """
+    prompt, target_str, metadata = _build_prompt_and_target(record)
+
     return Sample(
         input=prompt,
         target=target_str,
-        metadata={
-            "input_keys": input_keys,
-            "input_values": input_values,
-            "expected_output": expected_output,
-            "dictionary": dictionary,
-            "num_items": len(input_keys),
-        },
+        metadata=metadata,
     )
+
+
+@scorer(metrics={"accuracy": [accuracy(), stderr()]})
+def long_horizon_execution_scorer():
+    async def score(state: TaskState, target: Target):
+        response = state.output.completion
+
+        answer_pattern = re.compile(r"<answer>(.*?)</answer>", re.DOTALL)
+        match = answer_pattern.search(response)
+
+        if not match:
+            return Score(value="I", answer="", explanation="No <answer> tag found in response.")
+
+        content = match.group(1).strip()
+
+        try:
+            pred_values = [int(x.strip()) for x in content.split(",") if x.strip()]
+        except ValueError:
+            return Score(value="I", answer=content, explanation=f"Failed to parse integers from: {content}")
+
+        try:
+            exp_values = [int(x.strip()) for x in target.text.split(",") if x.strip()]
+
+        except (ValueError, AttributeError):
+            pred_str = ",".join(map(str, pred_values))
+            is_correct = pred_str == target.text
+            return Score(
+                value="C" if is_correct else "I",
+                answer=pred_str,
+                explanation=f"Expected: {target.text}, Predicted: {pred_str}",
+            )
+
+        is_correct = pred_values == exp_values
+        return Score(
+            value="C" if is_correct else "I",
+            answer=",".join(map(str, pred_values)),
+            explanation=(f"Expected {len(exp_values)} values, Got {len(pred_values)} values. Match: {is_correct}"),
+        )
+
+    return score
 
 
 long_horizon_execution = LightevalTaskConfig(
     name="long_horizon_execution",
+    prompt_function=long_horizon_execution_prompt_function,
     sample_fields=record_to_sample,
     solver=[generate(cache=True)],
+    scorer=long_horizon_execution_scorer(),
     hf_repo="arvindh75/Long-Horizon-Execution",
     hf_subset="default",
     evaluation_splits=("test",),
+    generation_size=32768,
+    metrics=[Metrics.exact_match],
 )
 
 TASKS_TABLE = [long_horizon_execution]


### PR DESCRIPTION
Approach described within #1056. 

Tasks: 
- [x] Initial scaffolding of `/tasks/tasks/long_horizon_execution.py`
- [x] Implement a custom scorer to parse `<answer>` tags. 
- [x] Complete implementation of `/tasks/tasks/long_horizon_execution.py`
- [x] Evaluation and Testing

STATUS: ready for review. 

Current behavior: 

When we run `lighteval tasks inspect long_horizon_execution`, the output has been shown below: 
```
... more lines
           "'basic', 'alive', 'cream', 'dress', 'black', 'brown', 'drama', "
           "'black', 'audio', 'brown', 'album', 'cover', 'avoid', 'aware', "
           "'event', 'dream', 'clean', 'clock', 'apple', 'above', 'close', "
           "'begin', 'allow', 'album', 'draft', 'brain', 'civil', 'faith', "
           "'death', 'coach', 'below', 'doubt', 'aware', 'cover', 'final', "
           "'allow', 'avoid', 'ahead', 'cross', 'child', 'cream', 'error', "
           "'break', 'brief', 'clock', 'final', 'dance', 'award', 'every', "
           "'chief', 'could', 'dream', 'begin', 'burst', 'audio', 'album', "
           "'cross', 'doubt', 'blood', 'child', 'brand', 'brand', 'extra', "
           "'broad', 'cloud', 'check', 'after', 'chart', 'basic', 'child', "
           "'coach', 'chair', 'faith', 'earth', 'audio', 'basic', 'field', "
           "'cloud', 'draft', 'apply', 'court', 'black', 'ahead', 'burst', "
           "'crowd', 'depth', 'enemy', 'drink', 'first', 'could', 'false', "
           "'could', 'blame', 'first', 'album', 'crowd', 'first', 'broad', "
           "'extra', 'clock', 'chart', 'fiber', 'board', 'earth', 'being', "
           "'alive', 'chart', 'avoid', 'dress', 'cloud', 'clean', 'avoid', "
           "'crash', 'clean', 'arise', 'death', 'brand', 'error']\n"
           '\n'
           'Your task: Calculate the cumulative sum after each key. The first '
           'sum is just the value of the first key. The second sum is the '
           'first value plus the second value, and so on.\n'
           '\n'
           'IMPORTANT:\n'
           '- Output your answer as a single line with comma-separated values '
           'inside <answer></answer> tags\n'
           '- Do not include any other text outside the answer tags\n'
           '- Format: <answer>value1,value2,value3,...</answer>\n'
           '- Example: If the cumulative sums are [5, 8, 12], output: '
           '<answer>5,8,12</answer>\n'
           '\n'
           'Your answer:',
  'sampling_methods': [],
  'specific': None,
  'stop_sequences': (),
  'task_name': 'long_horizon_execution',
  'unconditioned_query': None,
  'use_logits': False}
```