### PR TITLE
[DOC] Fix Dev Dependencies Install Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ If you're adding a **new feature**, please *open an issue first*.
 If you open a PR, don't forget to **run the styling**!
 
 ```bash
-pip install -e .[dev]
+pip install -e ".[dev]"
 pre-commit install
 pre-commit run --all-files
 ```


### PR DESCRIPTION
This PR fixes the development-dependencies installation command so that it works universally across all terminals and operating systems. While setting up a development environment on macOS, I discovered that the common command `pip install -e .[dev]` fails on `zsh,` the default shell on macOS, because `zsh` interprets the square brackets as a glob pattern instead of passing them to pip. This results in errors such as “no matches found.”

To ensure compatibility on macOS, Linux, and Windows, this PR updates the documentation and scripts to use the correctly quoted form:

`pip install -e ".[dev]"`