### PR TITLE
When customizing the save path, modify the "save_details" location

### DIFF
--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -321,7 +321,6 @@ class EvaluationTracker:
             model = org_model_parts[1] if len(org_model_parts) >= 2 else org_model_parts[0]
             output_dir = self.output_dir
             output_dir_details = Path(self.results_path_template.format(output_dir=output_dir, org=org, model=model)) / "details"
-            return output_dir_details
         else:
             output_dir_details = Path(self.output_dir) / "details" / self.general_config_logger.model_name.strip("/")
 
@@ -343,8 +342,7 @@ class EvaluationTracker:
     def load_details_datasets(self, date_id: str, task_names: list[str]) -> dict[str, Dataset]:
         output_dir_details_sub_folder = self._get_details_sub_folder(date_id)
         logger.info(f"Loading details from {output_dir_details_sub_folder}")
-        if self.results_path_template is None:
-            date_id = output_dir_details_sub_folder.name  # Overwrite date_id in case of latest
+        date_id = output_dir_details_sub_folder.name  # Overwrite date_id in case of latest
         details_datasets = {}
         for file in self.fs.glob(str(output_dir_details_sub_folder / f"details_*_{date_id}.parquet")):
             task_name = Path(file).stem.replace("details_", "").replace(f"_{date_id}", "")


### PR DESCRIPTION
If the local model path is used, such as /mnt/public/xxxx, and the results_path_template is not specified, the path for saving the results will be extremely long and the directory will be difficult to read. 

Now, we can specify the results_path_template so that the files will be saved in the corresponding path. However, if save_details is specified, the details will still be saved in the original path, which is not convenient for reading the parquet corresponding to the details. Therefore, I change that under the condition that the user specifies the saving path, the details can also be placed in the corresponding directory.