### PR TITLE
Fix typo in few_shots_select option error message ("fbalanced" → "balanced")

### DIFF
--- a/src/lighteval/tasks/prompt_manager.py
+++ b/src/lighteval/tasks/prompt_manager.py
@@ -206,7 +206,7 @@ class FewShotSampler:
 
         if few_shots_select not in ALLOWED_SELECTIONS:
             raise ValueError(
-                f"few_shots_select must be one of f{','.join(ALLOWED_SELECTIONS[:-1])} or {ALLOWED_SELECTIONS[-1]}, not {few_shots_select}"
+                f"few_shots_select must be one of {','.join(ALLOWED_SELECTIONS[:-1])} or {ALLOWED_SELECTIONS[-1]}, not {few_shots_select}"
             )
 
         self.few_shots_select = FewShotSelection[few_shots_select]


### PR DESCRIPTION
This PR fixes a typo in the few_shots_select error message where "fbalanced" was displayed instead of "balanced".

Before:"ValueError: few_shots_select must be one of fbalanced,random,sequential,random_sampling_from_train or random_sampling, ..." 

After:"ValueError: few_shots_select must be one of balanced,random,sequential,random_sampling_from_train or random_sampling, ..."

This change corrects the spelling and improves error clarity when an invalid few_shots_select option is provided.

No functional behavior changes, only error message text is updated.