### PR TITLE
Fix specific error in truthfulqa

### DIFF
--- a/src/lighteval/tasks/tasks/truthfulqa.py
+++ b/src/lighteval/tasks/tasks/truthfulqa.py
@@ -50,7 +50,7 @@ def truthful_qa_generative_prompt(line, task_name: str = None):
         task_name=task_name,
         query=line["question"].strip(),
         choices=correct_answers + incorrect_answers,
-        gold_index=list(range(len(correct_answers)))
+        gold_index=list(range(len(correct_answers))),
     )
 
 


### PR DESCRIPTION
truthfulqa:gen has no key "mc1_targets", so it will raise an error like:
```
Traceback (most recent call last):
  File "/mnt/shared-storage-user/ai4agr-share/chenzihong/miniconda3/envs/lighteval/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/mnt/shared-storage-user/ai4agr-share/chenzihong/miniconda3/envs/lighteval/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/mnt/shared-storage-user/ai4agr-share/chenzihong/code/lighteval/scripts/eval.py", line 103, in <module>
    main()
  File "/mnt/shared-storage-user/ai4agr-share/chenzihong/code/lighteval/scripts/eval.py", line 68, in main
    pipeline = Pipeline(
  File "/mnt/shared-storage-user/ai4agr-share/chenzihong/code/lighteval/src/lighteval/pipeline.py", line 142, in __init__
    self._init_tasks_and_requests(tasks=tasks)
  File "/mnt/shared-storage-user/ai4agr-share/chenzihong/code/lighteval/src/lighteval/pipeline.py", line 223, in _init_tasks_and_requests
    self.documents_dict = {
  File "/mnt/shared-storage-user/ai4agr-share/chenzihong/code/lighteval/src/lighteval/pipeline.py", line 224, in <dictcomp>
    task.full_name: task.get_docs(self.pipeline_parameters.max_samples) for _, task in self.tasks_dict.items()
  File "/mnt/shared-storage-user/ai4agr-share/chenzihong/code/lighteval/src/lighteval/tasks/lighteval_task.py", line 382, in get_docs
    eval_docs = self.eval_docs()
  File "/mnt/shared-storage-user/ai4agr-share/chenzihong/code/lighteval/src/lighteval/tasks/lighteval_task.py", line 359, in eval_docs
    self._docs = self._get_docs_from_split(self.evaluation_split)
  File "/mnt/shared-storage-user/ai4agr-share/chenzihong/code/lighteval/src/lighteval/tasks/lighteval_task.py", line 309, in _get_docs_from_split
    doc = self.formatter(item, self.name)
  File "/mnt/shared-storage-user/ai4agr-share/chenzihong/code/lighteval/src/lighteval/tasks/tasks/truthfulqa.py", line 54, in truthful_qa_generative_prompt
    specific={"len_mc1": len(line["mc1_targets"]["choices"])},
KeyError: 'mc1_targets'
```
See: https://huggingface.co/datasets/truthfulqa/truthful_qa