### PR TITLE
Fix: pass through custom_tasks and enable multilingual in eval command

### DIFF
--- a/src/lighteval/main_inspect.py
+++ b/src/lighteval/main_inspect.py
@@ -435,7 +435,7 @@ def eval(  # noqa C901
 ):
     from lighteval.tasks.registry import Registry
 
-    registry = Registry(tasks=tasks, custom_tasks=None, load_multilingual=False)
+    registry = Registry(tasks=tasks, custom_tasks=custom_tasks, load_multilingual=True)
     task_configs = registry.task_to_configs
     inspect_ai_tasks = []
 


### PR DESCRIPTION
## Summary
- The `eval()` function in `main_inspect.py` accepts `--custom-tasks` and multilingual task names as CLI parameters but hardcodes `custom_tasks=None` and `load_multilingual=False` when creating the `Registry`, silently ignoring both.

## Test plan
- [x] Verified that multilingual tasks (e.g. `maime25:da`) are now discoverable via `lighteval eval`
- [x] Verified that `--custom-tasks` is properly passed through to the Registry