### PR TITLE
fix(normalizations): guard against index out of range in LogProbToken…

### DIFF
--- a/src/lighteval/metrics/normalizations.py
+++ b/src/lighteval/metrics/normalizations.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import logging
 import re
 import string
 import sys
@@ -30,6 +31,8 @@ from typing import Callable
 from lighteval.metrics.utils.linguistic_tokenizers import get_word_tokenizer
 from lighteval.utils.imports import Extra, requires
 from lighteval.utils.language import Language
+
+logger = logging.getLogger(__name__)
 
 
 # From HELM
@@ -523,8 +526,14 @@ def normalize_log_probs(
             normalized_log_probs = [choices_logprob[ix] / len(choice) for ix, choice in enumerate(choices_text)]
         case LogProbTokenNorm():
             assert choices_tokens is not None, "choices_tokens must be provided for token normalization"
+            n = min(len(choices_logprob), len(choices_tokens))
+            if n < len(choices_logprob):
+                logger.warning(
+                    f"choices_tokens length ({len(choices_tokens)}) is less than choices_logprob length "
+                    f"({len(choices_logprob)}). This may indicate corrupted cache data. Truncating to {n} elements."
+                )
             normalized_log_probs = [
-                choices_logprob[ix] / len(choices_tokens[ix]) for ix in range(len(choices_logprob))
+                choices_logprob[ix] / len(choices_tokens[ix]) for ix in range(n)
             ]
         case LogProbPMINorm():
             assert unconditioned_logprob is not None, "unconditioned_logprob must be provided for PMI normalization"


### PR DESCRIPTION
…Norm

## Problem

When running evaluations with cached predictions, `normalize_log_probs` crashes with an `IndexError: list index out of range` inside the `LogProbTokenNorm` case. This happens because the cached `output_tokens` list can be shorter than `choices_logprob`, for example when a task's choices change between runs but the cache is not invalidated.

Affected path:
`lighteval/metrics/normalizations.py` → `normalize_log_probs` → `LogProbTokenNorm` branch

## Fix

- Use `min(len(choices_logprob), len(choices_tokens))` to safely cap the iteration range instead of blindly iterating over `len(choices_logprob)`.
- Emit a `logger.warning` when truncation occurs so users are alerted to potential cache corruption and can take action (e.g. clearing the cache).
- Add a module-level `logger = logging.getLogger(__name__)` for consistent logging.

## Changes

- `src/lighteval/metrics/normalizations.py`
  - Added `import logging` and module-level logger
  - Replaced bare list comprehension in `LogProbTokenNorm` with length-guarded version

## How to reproduce the original bug

1. Run an evaluation that uses `LogProbTokenNorm` (e.g. `belebele_mkd_Cyrl_cf`).
2. Allow results to be cached.
3. Modify the number of choices for the task, or use a stale cache from a previous run.
4. Re-run, the pipeline crashes at the metric computation stage with `IndexError: list index out of range`.