### PR TITLE
Fix typos in math_comparison.py and sample_comparison.py

### DIFF
--- a/src/lighteval/metrics/utils/math_comparison.py
+++ b/src/lighteval/metrics/utils/math_comparison.py
@@ -496,7 +496,7 @@ def sympy_expr_eq(gold: Basic | MatrixBase, pred: Basic | MatrixBase, precision:
         except Exception:  # noqa: E722
             pass
 
-    # If the target is relational, but the refernce is not, it's possible it's a case of a=x+1+z, so we just take x+1+z
+    # If the target is relational, but the reference is not, it's possible it's a case of a=x+1+z, so we just take x+1+z
     # We only do this if the lhs of the first equation is fully symbolic, to prevent simplifying x+y+2z = 1
     if is_assignment_relation(gold) and not is_equation(pred):
         gold = take_last_relation(gold).rhs

--- a/tests/slow_tests/sample_comparison.py
+++ b/tests/slow_tests/sample_comparison.py
@@ -71,7 +71,7 @@ def _compare_model_responses(current, reference):
 
         # Special handling for logprobs field
         if field_name in ["input_tokens", "output_tokens"]:
-            # input and ouput tokens are lists of tensors, we need to convert
+            # input and output tokens are lists of tensors, we need to convert
             # them to plain lists
             current_val = _to_plain_list(current_val)
             reference_val = _to_plain_list(reference_val)


### PR DESCRIPTION
## Summary
- Fix "refernce" -> "reference" in `src/lighteval/metrics/utils/math_comparison.py` (line 499)
- Fix "ouput" -> "output" in `tests/slow_tests/sample_comparison.py` (line 74)