### PR TITLE
Add count column to markdown results summary

### DIFF
--- a/src/lighteval/logging/evaluation_tracker.py
+++ b/src/lighteval/logging/evaluation_tracker.py
@@ -212,10 +212,12 @@ class EvaluationTracker:
     def results(self):
         config_general = asdict(self.general_config_logger)
         config_general["model_config"] = config_general["model_config"].model_dump()
+        sample_counts = {task_name: len(task_details) for task_name, task_details in self.details_logger.details.items()}
         results = {
             "config_general": config_general,
             "results": self.metrics_logger.metric_aggregated,
             "versions": self.versions_logger.versions,
+            "n_samples": sample_counts,
             "config_tasks": self.task_config_logger.tasks_configs,
             "summary_tasks": self.details_logger.compiled_details,
             "summary_general": asdict(self.details_logger.compiled_details_over_all_tasks),
@@ -368,10 +370,12 @@ class EvaluationTracker:
         Returns:
             dict: Dictionary containing all experiment information including config, results, versions, and summaries
         """
+        sample_counts = {task_name: len(task_details) for task_name, task_details in self.details_logger.details.items()}
         to_dump = {
             "config_general": asdict(self.general_config_logger),
             "results": self.metrics_logger.metric_aggregated,
             "versions": self.versions_logger.versions,
+            "n_samples": sample_counts,
             "config_tasks": self.task_config_logger.tasks_configs,
             "summary_tasks": self.details_logger.compiled_details,
             "summary_general": asdict(self.details_logger.compiled_details_over_all_tasks),

--- a/src/lighteval/utils/utils.py
+++ b/src/lighteval/utils/utils.py
@@ -249,24 +249,27 @@ def make_results_table(result_dict):
         # Returns markdown table with task, version, metric, value, ±, stderr columns
     """
     md_writer = MarkdownTableWriter()
-    md_writer.headers = ["Task", "Version", "Metric", "Value", "", "Stderr"]
+    md_writer.headers = ["Task", "Version", "Metric", "Value", "Count", "", "Stderr"]
 
     values = []
+    task_sample_counts = result_dict.get("n_samples", {})
 
     for k in sorted(result_dict["results"].keys()):
         dic = result_dict["results"][k]
         version = result_dict["versions"][k] if k in result_dict["versions"] else ""
+        sample_count = task_sample_counts.get(k, "")
         for m, v in dic.items():
             if m.endswith("_stderr"):
                 continue
 
             if m + "_stderr" in dic:
                 se = dic[m + "_stderr"]
-                values.append([k, version, m, "%.4f" % v, "±", "%.4f" % se])
+                values.append([k, version, m, "%.4f" % v, sample_count, "±", "%.4f" % se])
             else:
-                values.append([k, version, m, "%.4f" % v, "", ""])
+                values.append([k, version, m, "%.4f" % v, sample_count, "", ""])
             k = ""
             version = ""
+            sample_count = ""
     md_writer.value_matrix = values
 
     return md_writer.dumps()

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -22,7 +22,7 @@
 
 import unittest
 
-from lighteval.utils.utils import remove_reasoning_tags
+from lighteval.utils.utils import make_results_table, remove_reasoning_tags
 
 
 class TestRemoveReasoningTags(unittest.TestCase):
@@ -61,3 +61,28 @@ class TestRemoveReasoningTags(unittest.TestCase):
         tag_pairs = [("<think>", "</think>")]
         result = remove_reasoning_tags(text, tag_pairs)
         self.assertEqual(result, "<think> Reasoning section. Answer section")
+
+
+class TestMakeResultsTable(unittest.TestCase):
+    def test_includes_count_column_when_n_samples_present(self):
+        result_dict = {
+            "results": {"community:ether0:loose:0": {"ether0_accuracy": 0.0, "ether0_accuracy_stderr": 0.0}},
+            "versions": {"community:ether0:loose:0": "0"},
+            "n_samples": {"community:ether0:loose:0": 10},
+        }
+
+        table = make_results_table(result_dict)
+
+        self.assertIn("|Task                    |Version|Metric         |Value|Count|", table)
+        self.assertIn("|community:ether0:loose:0|      0|ether0_accuracy|    0|   10|", table)
+
+    def test_keeps_count_blank_when_n_samples_missing(self):
+        result_dict = {
+            "results": {"task_a": {"accuracy": 0.5, "accuracy_stderr": 0.1}},
+            "versions": {"task_a": "1"},
+        }
+
+        table = make_results_table(result_dict)
+
+        self.assertIn("|Task  |Version|Metric  |Value|Count|", table)
+        self.assertIn("|task_a|      1|accuracy|  0.5|     |", table)


### PR DESCRIPTION
## Summary
- add per-task 
_samples to the exported evaluation results dictionary
- render a new Count column in make_results_table markdown output
- add unit tests covering populated and missing count behavior

## Why
Issue #804 asks for the markdown summary to show how many questions were evaluated so low scores are easier to interpret.

## Validation
- python3 -m py_compile src/lighteval/logging/evaluation_tracker.py src/lighteval/utils/utils.py tests/unit/utils/test_utils.py
- Full unit test run was not possible in this environment because WSL Python is missing pip/pytest.
