### PR TITLE
Fix litellm connection pool limiting concurrent_requests

### DIFF
--- a/src/lighteval/models/endpoints/litellm_model.py
+++ b/src/lighteval/models/endpoints/litellm_model.py
@@ -25,6 +25,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from json import JSONDecodeError
 
+import httpx
 import requests
 from tqdm import tqdm
 
@@ -158,6 +159,16 @@ class LiteLLMClient(LightevalModel):
         self.pairwise_tokenization = False
         litellm.drop_params = True
         litellm.verbose = config.verbose
+
+        # Configure litellm's global HTTP client to match concurrent_requests,
+        # avoiding the default httpx connection pool limit of 100.
+        litellm.client_session = httpx.Client(
+            limits=httpx.Limits(
+                max_connections=config.concurrent_requests,
+                max_keepalive_connections=config.concurrent_requests,
+            ),
+            timeout=httpx.Timeout(config.timeout) if config.timeout else httpx.Timeout(None),
+        )
         self.prompt_manager = PromptManager(
             use_chat_template=True, tokenizer=self.tokenizer, system_prompt=config.system_prompt
         )


### PR DESCRIPTION
## Problem

Setting `concurrent_requests` above 100 (e.g. 128) doesn't actually increase parallelism to the vLLM server — requests get bottlenecked at 100.

The root cause is httpx's default `max_connections=100` on its connection pool. Since litellm uses httpx internally for `litellm.completion()`, the ThreadPoolExecutor happily spawns 128 threads but they all block waiting for one of the 100 available connections.

## Fix

Set `litellm.client_session` with an `httpx.Client` whose pool limits match `config.concurrent_requests`. This is litellm's [officially documented approach](https://docs.litellm.ai/docs/completion/shared_session) for providing a custom HTTP session.

No new dependencies — httpx is already a transitive dep of litellm.

## Testing

Verified locally against a vLLM server with `concurrent_requests: 128`; active connections now exceed 100 as expected. Default config (`concurrent_requests: 10`) works as before.