### PR TITLE
Remove deprecated prompt_token_ids wrapping in vLLM backend

### DIFF
--- a/src/lighteval/metrics/utils/llm_as_judge.py
+++ b/src/lighteval/metrics/utils/llm_as_judge.py
@@ -296,9 +296,7 @@ class JudgeLM:
 
     def __call_vllm(self, prompt):
         tokenized = [self.tokenizer.apply_chat_template(p) for p in prompt]
-        # Convert token IDs to TokensPrompt format for vLLM v0.15+
-        prompts = [{"prompt_token_ids": token_ids} for token_ids in tokenized]
-        output = self.pipe.generate(prompts=prompts, sampling_params=self.sampling_params, use_tqdm=True)
+        output = self.pipe.generate(prompts=tokenized, sampling_params=self.sampling_params, use_tqdm=True)
         outputs = [output.outputs[0].text for output in output]
         return outputs
 

--- a/src/lighteval/models/vllm/vllm_model.py
+++ b/src/lighteval/models/vllm/vllm_model.py
@@ -439,9 +439,7 @@ class VLLMModel(LightevalModel):
             @ray.remote(num_gpus=self.tensor_parallel_size)
             def run_inference_one_model(model_args: dict, sampling_params: SamplingParams, requests):
                 llm = LLM(**model_args)
-                # Convert token IDs to TokensPrompt format for vLLM v0.15+
-                prompts = [{"prompt_token_ids": req} for req in requests]
-                return llm.generate(prompts=prompts, sampling_params=sampling_params)
+                return llm.generate(prompts=requests, sampling_params=sampling_params)
 
             # dispatch requests to all self.data_parallel_size workers, in interleaved fashion
             # interleaved important to balance context lengths across workers
@@ -458,12 +456,8 @@ class VLLMModel(LightevalModel):
                 if x is not None
             ]
         else:
-            from vllm.inputs import TokenInputs
-
-            # Convert token IDs to TokensPrompt format for vLLM v0.15+
-            prompts = [TokenInputs(prompt_token_ids=token_ids) for token_ids in inputs]
             outputs = self.model.generate(
-                prompts=prompts,
+                prompts=inputs,
                 sampling_params=sampling_params,
                 use_tqdm=True,
             )


### PR DESCRIPTION
## Context

Follow-up to #1173 which upgraded vLLM to `>=0.11.0`. A few call sites still used the old `prompt_token_ids` wrapping patterns that are no longer needed.

Relates to #1002

## What changed

vLLM's [`PromptType`](https://github.com/vllm-project/vllm/blob/main/vllm/inputs/data.py) includes `list[int]` directly in `DecoderOnlyPrompt`, so we can pass token ID lists to `LLM.generate()` without any wrapping:

```
PromptType = DecoderOnlyPrompt | EncoderDecoderPrompt
DecoderOnlyPrompt = str | TextPrompt | list[int] | TokensPrompt | ExplicitEncoderDecoderPrompt
```

Removed:
- `{"prompt_token_ids": ...}` dict wrapping in the ray data-parallel path (`vllm_model.py`)
- `TokenInputs(prompt_token_ids=...)` wrapping + its import in the single-GPU path (`vllm_model.py`)
- `{"prompt_token_ids": ...}` dict wrapping in the LLM-as-judge vLLM path (`llm_as_judge.py`)

Now all three call sites just pass `list[list[int]]` directly, which is simpler and works across vLLM 0.11 through 0.17+.

## Test plan

- Verified against vLLM docs that `list[int]` is a valid `PromptType` from 0.10.2 onwards
- Existing vLLM tests in the repo should continue to pass (no behavioral change, just removing unnecessary wrapping)