### PR TITLE
[Bugfix] litellm backend should iterate over docs in a split not entire dataset

### DIFF
--- a/src/lighteval/models/endpoints/litellm_model.py
+++ b/src/lighteval/models/endpoints/litellm_model.py
@@ -347,7 +347,7 @@ class LiteLLMClient(LightevalModel):
             position=0,
             disable=self.disable_tqdm,
         ):
-            contexts = [self.prompt_manager.prepare_prompt_api(doc) for doc in dataset]
+            contexts = [self.prompt_manager.prepare_prompt_api(doc) for doc in split]
             max_new_tokens = split[0].generation_size  # could be none
             return_logits = split[0].use_logits
             num_samples = split[0].num_samples


### PR DESCRIPTION
Right now, litellm backend runs more requests by iterating over all docs in the entire datasets instead of the corresponding dataset split. 