### PR TITLE
[LiteLLM Enhancement] Enable extra_body dict for litellm backend 

### DIFF
--- a/src/lighteval/models/abstract_model.py
+++ b/src/lighteval/models/abstract_model.py
@@ -133,24 +133,24 @@ class ModelConfig(BaseModel, extra="forbid"):
                 'model': {'model_name': 'gpt2', 'use_cache': True, 'generation_parameters': {'temperature': 0.7}},
             }
         """
-        # Looking for generation_parameters in the model_args
-        generation_parameters_dict = None
-        pattern = re.compile(r"(\w+)=(\{.*\}|[^,]+)")
-        matches = pattern.findall(args)
-        for key, value in matches:
-            key = key.strip()
-            if key == "generation_parameters":
-                # Keys must be quoted (since they are strings)
-                gen_params = re.sub(r"(\w+):", r'"\1":', value)
-                # for k, v where v are strings, we quote them too
-                gen_params = re.sub(r":\s*([A-Za-z_][\w.-]*)\s*(?=[,}])", r':"\1"', gen_params)
-                generation_parameters_dict = json.loads(gen_params)
+        # Extract all key={...} dict parameters (e.g. generation_parameters, extra_body)
+        dict_params = {}
+        dict_pattern = re.compile(r"(\w+)=(\{[^}]*\})")
+        for match in dict_pattern.finditer(args):
+            key = match.group(1)
+            value = match.group(2)
+            # Keys must be quoted (since they are strings)
+            parsed = re.sub(r"(\w+):", r'"\1":', value)
+            # for k, v where v are strings, we quote them too
+            parsed = re.sub(r":\s*([A-Za-z_][\w.-]*)\s*(?=[,}])", r':"\1"', parsed)
+            dict_params[key] = json.loads(parsed)
 
-        args = re.sub(r"generation_parameters=\{.*?\},?", "", args).strip(",")
-        model_config = {k.split("=")[0]: k.split("=")[1] if "=" in k else True for k in args.split(",")}
+        # Strip dict params from args string, then parse remaining simple key=value pairs
+        remaining = dict_pattern.sub("", args)
+        remaining = re.sub(r",+", ",", remaining).strip(",")
+        model_config = {k.split("=")[0]: k.split("=")[1] if "=" in k else True for k in remaining.split(",") if k}
 
-        if generation_parameters_dict is not None:
-            model_config["generation_parameters"] = generation_parameters_dict
+        model_config.update(dict_params)
 
         return model_config
 

--- a/src/lighteval/models/endpoints/litellm_model.py
+++ b/src/lighteval/models/endpoints/litellm_model.py
@@ -131,6 +131,11 @@ class LiteLLMModelConfig(ModelConfig):
     api_retry_multiplier: float = 2.0
     timeout: float | None = None
 
+    # Extra body parameters passed through to the API request body.
+    # Useful for provider-specific params not in the standard OpenAI API,
+    # e.g., vLLM supports top_k, min_p, repetition_penalty via extra_body.
+    extra_body: dict | None = None
+
 
 @requires("litellm")
 class LiteLLMClient(LightevalModel):
@@ -153,6 +158,7 @@ class LiteLLMClient(LightevalModel):
         self.API_RETRY_SLEEP = config.api_retry_sleep
         self.API_RETRY_MULTIPLIER = config.api_retry_multiplier
         self.timeout = config.timeout
+        self.extra_body = config.extra_body
 
         self._tokenizer = encode
         self.pairwise_tokenization = False
@@ -164,6 +170,12 @@ class LiteLLMClient(LightevalModel):
 
         # Initialize cache for tokenization and predictions
         self._cache = SampleCache(config)
+
+        # Log sampling params so the user can verify what will be sent to the server
+        sampling_params = self.generation_parameters.to_litellm_dict()
+        if self.extra_body:
+            sampling_params["extra_body"] = self.extra_body
+        logger.info(f"Sampling parameters: {sampling_params}")
 
     def _prepare_stop_sequence(self, stop_sequence):
         """Prepare and validate stop sequence."""
@@ -210,6 +222,7 @@ class LiteLLMClient(LightevalModel):
             "n": num_samples,
             "caching": True,
             "timeout": self.timeout,
+            "extra_body": self.extra_body,
         }
 
         if "o1" in self.model:


### PR DESCRIPTION
In addition to standard OpenAI sampling args, vLLM server supports additional arguments via `extra_body` argument such as `top_k`, `min_p`, etc. Motivation for this feature is to enable running Qwen3.5 models with recommended sampling arguments which include for example `top_k` (see https://huggingface.co/Qwen/Qwen3.5-27B#using-qwen35-via-the-chat-completions-api).

This PR enables this feature through both interfaces: yaml and inline string.

1) yaml example:
```yaml
model_parameters:
  provider: "hosted_vllm"
  model_name: "hosted_vllm/<model_name>"
  base_url: "http://0.0.0.0:8000/v1"
  api_key: ""
  timeout: 1200
  concurrent_requests: 128
  generation_parameters:
    temperature: 0.6
    max_new_tokens: 65536
    top_p: 0.95
    seed: 0
  extra_body:
    top_k: 20
    min_p: 0.0
```

2) inline string
```bash
lighteval endpoint litellm \
"model_name=hosted_vllm/my_mdl,provider=hosted_vllm,base_url=http://0.0.0.0:8000/v1,timeout=120,concurrent_requests=8,extra_body={top_k:20,min_p:0.0,repetition_penalty:1.0},generation_parameters={temperature:1.0,max_new_tokens:65536,top_p:0.95,seed:42,presence_penalty:1.5}" \
"aime25|0" \
--output-dir ${OUTPUT_DIR} \
```