### PR TITLE
[Bugfix] Check all responses when n>1 instead of only the first one

### DIFF
--- a/src/lighteval/models/endpoints/litellm_model.py
+++ b/src/lighteval/models/endpoints/litellm_model.py
@@ -361,14 +361,13 @@ class LiteLLMClient(LightevalModel):
             responses = self.__call_api_parallel(contexts, return_logits, max_new_tokens, num_samples, stop_sequence)
 
             for response, context in zip(responses, contexts):
-                result: list[str] = [choice.message.content for choice in response.choices]
+                result: list[str] = [choice.message.content or "" for choice in response.choices]
                 reasonings: list[str | None] = [
                     getattr(choice.message, "reasoning_content", None) for choice in response.choices
                 ]
 
                 cur_response = ModelResponse(
-                    # In empty responses, the model should return an empty string instead of None
-                    text=result if result[0] else [""],
+                    text=result,
                     reasonings=reasonings,
                     input=context,
                 )


### PR DESCRIPTION
When generating multiple completions (n>1 in sampling args), there might be cases when some of those completions have crashed/errored/etc and this breaks post-processing of results in lighteval as it attempts to compute metrics on empty responses. This is happening because the "non-emptiness check" is done only on the first completion, and not all of them. 

Before this PR (sorry for screenshot; can provide full logs later if needed)
<img width="837" height="787" alt="image" src="https://github.com/user-attachments/assets/62a2b465-f8c7-4989-b7a5-491435837f18" />

After this PR: post-processing and evals are completed correctly