### PR TITLE
Add --load-tasks-multilingual and fix --custom-tasks for inspect backend

### DIFF
--- a/src/lighteval/main_inspect.py
+++ b/src/lighteval/main_inspect.py
@@ -37,6 +37,7 @@ from pytablewriter import MarkdownTableWriter
 from typer import Argument, Option
 from typing_extensions import Annotated
 
+from lighteval.cli_args import load_tasks_multilingual as load_tasks_multilingual_arg
 from lighteval.models.abstract_model import InspectAIModelConfig
 from lighteval.tasks.lighteval_task import LightevalTaskConfig
 
@@ -432,10 +433,11 @@ def eval(  # noqa C901
             rich_help_panel=HELP_PANEL_NAME_4,
         ),
     ] = False,
+    load_tasks_multilingual: load_tasks_multilingual_arg.type = load_tasks_multilingual_arg.default,
 ):
     from lighteval.tasks.registry import Registry
 
-    registry = Registry(tasks=tasks, custom_tasks=None, load_multilingual=False)
+    registry = Registry(tasks=tasks, custom_tasks=custom_tasks, load_multilingual=load_tasks_multilingual)
     task_configs = registry.task_to_configs
     inspect_ai_tasks = []
 


### PR DESCRIPTION
## Summary

The inspect backend (`lighteval eval`) hardcodes `custom_tasks=None` and `load_multilingual=False` when constructing the `Registry`, making it impossible to use multilingual or custom tasks. All other backends (vllm, accelerate, sglang, endpoint) properly accept and pass through both parameters.

This PR:
- Adds `--load-tasks-multilingual` CLI flag to the inspect backend, reusing the shared `load_tasks_multilingual` arg from `cli_args.py` (same pattern as all other backends)
- Fixes `custom_tasks` being hardcoded to `None` — the parameter already exists in the function signature but was never forwarded to `Registry`

### Changes (3 lines in `main_inspect.py`)

1. Import the shared CLI arg definition
2. Add the `load_tasks_multilingual` parameter to the `eval()` function
3. Pass both `custom_tasks` and `load_tasks_multilingual` to `Registry()` instead of hardcoded values

### Usage

```bash
lighteval eval "vllm/model" "mgsm:fi" --load-tasks-multilingual
lighteval eval "vllm/model" "my_task" --custom-tasks path/to/tasks.py
```

## Test plan

- [x] Verified `--load-tasks-multilingual` flag appears in CLI help
- [x] Verified multilingual tasks load when flag is set (Registry finds tasks from `multilingual/tasks/`)
- [x] End-to-end eval run with `maime25:fi` (30 samples) completed successfully on AMD MI325X cluster using vLLM backend through inspect-ai
- [x] Ruff formatting passes