### PR TITLE
fix(vllm): use max prompt length for batch context-length check

### DIFF
--- a/src/lighteval/models/vllm/vllm_model.py
+++ b/src/lighteval/models/vllm/vllm_model.py
@@ -355,7 +355,7 @@ class VLLMModel(LightevalModel):
             # The choice we go for here is to avoid truncating the prompt if we can, since it
             # should have been managed by the prompt creator/few shot manager if requested by the user.
             inputs = tokenized["input_ids"]
-            context_size = len(inputs[0])
+            context_size = max(len(inp) for inp in inputs)
 
             # left truncate the inputs to the maximum length
             if self.max_length is None:
@@ -365,7 +365,7 @@ class VLLMModel(LightevalModel):
             elif max_new_tokens is not None:
                 if context_size + max_new_tokens > self.max_length:
                     logger.warning(
-                        f"{context_size + max_new_tokens=} which is greater than {self.max_length=}. Truncating context to {self.max_length - max_new_tokens} tokens."
+                        f"Batch max length {context_size} + {max_new_tokens=} which is greater than {self.max_length=}. Truncating context to {self.max_length - max_new_tokens} tokens."
                     )
                     context_size = self.max_length - max_new_tokens
                     if context_size < 0:
@@ -377,7 +377,7 @@ class VLLMModel(LightevalModel):
             else:
                 if context_size > self.max_length:
                     logger.warning(
-                        f"{context_size=} which is greater than {self.max_length=}. Truncating context to {self.max_length} tokens."
+                        f"Batch max length {context_size=} which is greater than {self.max_length=}. Truncating context to {self.max_length} tokens."
                     )
                     context_size = self.max_length
                     inputs = [input[-context_size:] for input in inputs]


### PR DESCRIPTION
In `VLLMModel._greedy_until`, the context-length check before truncation used `len(inputs[0])` — the length of only the first prompt in the batch — instead of the maximum length across all prompts. For batches with variable-length prompts, any prompt longer than the first would silently bypass truncation and get passed to vLLM with a token count exceeding `max_model_len`, causing runtime errors or silent truncation inside the engine.

The fix replaces `len(inputs[0])` with `max(len(inp) for inp in inputs)` so the check is conservative over the entire batch, and updates the related warning messages to reflect that the reported size is the batch maximum.

Fixes #1204.