### PR TITLE
[CI] Bump style-bot-action to hardened SHA (TOCTOU fix)

### DIFF
--- a/.github/workflows/pr_style_bot.yaml
+++ b/.github/workflows/pr_style_bot.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   style:
-    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@f28006016356b5811bf92d45d6c39f9585f2ff4c
+    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@d87e6e68f8edeab7aa706e88c47f4039744707e9
     with:
       python_quality_dependencies: "[quality]"
     secrets:


### PR DESCRIPTION
## Summary

Bumps the pinned SHA of the reusable `style-bot-action` workflow to include security hardening against TOCTOU attacks.

- `f28006016356b5811bf92d45d6c39f9585f2ff4c` → `d87e6e68f8edeab7aa706e88c47f4039744707e9`

## What changed in the new SHA (huggingface/huggingface_hub#4183)

- **SHA pinning**: checkout now uses `pr.head.sha` (immutable) instead of the branch ref name
- **Credential isolation**: `persist-credentials: false` — `bot_token` is never accessible during `pip install` / `make style`
- **Job separation**: untrusted code runs in a sandboxed job; the push happens in a separate trusted job via a git patch artifact
- **Server-side timestamp guard**: verifies via GraphQL `pushedDate` that the head commit was pushed *before* the `@bot /style` comment — prevents a contributor from sneaking in a malicious commit just before a maintainer triggers the bot
- **Double SHA re-validation**: PR head SHA is re-checked via API both before running untrusted code and before pushing

> ⚠️ Depends on huggingface/huggingface_hub#4183 being merged first.