### PR TITLE
fix: prevent IndexError in Doc.get_golds() for out-of-bounds gold_index

### DIFF
--- a/src/lighteval/tasks/requests.py
+++ b/src/lighteval/tasks/requests.py
@@ -214,11 +214,23 @@ class Doc:
     num_samples: int = 1  # number of samples to generate for each sample
     generation_grammar: None = None
 
-    def get_golds(self):
-        """Return gold targets extracted from the target dict"""
+    def get_golds(self) -> list:
+        """Return gold targets extracted from the target dict.
+        
+        Returns:
+            list: The gold answer strings corresponding to gold_index indices.
+            
+        Raises:
+            ValueError: If gold_index refers to an out-of-bounds choice index.
+        """
         gold_indices = as_list(self.gold_index)
         golds = []
+        num_choices = len(self.choices)
         for gold_ix in gold_indices:
+            if gold_ix >= num_choices:
+                raise ValueError(
+                    f"gold_index {gold_ix} is out of bounds for choices of size {num_choices}"
+                )
             golds.extend(as_list(self.choices[gold_ix]))
         return golds
 


### PR DESCRIPTION
Fixed the bug described in issue #1162. Here's what was wrong and how I fixed it:

**Root Cause:** In `Doc.get_golds()`, the `gold_index` value was used directly to index `self.choices` without bounds checking. When `gold_index` exceeded `len(choices) - 1`, it raised an unhelpful `IndexError: list index out of range`.

**The Fix:** Added a bounds check before accessing `self.choices[gold_ix]`. Now if `gold_ix >= num_choices`, a descriptive `ValueError` is raised with the offending index and the actual size of choices.

**Changes:**
- `src/lighteval/tasks/requests.py`: Added bounds validation in `get_golds()` method
- Returns `ValueError` with a clear message instead of a cryptic `IndexError`
- Added type hints and docstring improvements

**Testing:** Syntax check passed. The fix correctly converts the `IndexError` into a `ValueError` with actionable error message.

Closes #1162