### PR TITLE
fix: guard choices[0] and message=None before content access in llm_as_judge

### DIFF
--- a/src/lighteval/metrics/utils/llm_as_judge.py
+++ b/src/lighteval/metrics/utils/llm_as_judge.py
@@ -436,6 +436,8 @@ class JudgeLM:
                         max_tokens=self.max_tokens,
                         n=1,
                     )
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     text = response.choices[0].message.content
                     return text
                 except Exception as e:


### PR DESCRIPTION
## Summary

In `src/lighteval/metrics/utils/llm_as_judge.py`, the API retry loop at line 439 accesses `response.choices[0].message.content` without checking:
- Whether `choices` is non-empty (can be `[]` on API error or rate-limiting → `IndexError`)
- Whether `choices[0].message` is non-None (Gemini returns `None` on `PROHIBITED_CONTENT` with HTTP 200 → `AttributeError`)

This fix adds the comprehensive guard:
```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```
The `ValueError` is caught by the inner `except Exception` block that already handles API errors, so the retry logic continues as designed.

Static analysis via [pact](https://github.com/qizwiz/pact) (Z3 Fixedpoint datalog, `llm_response_unguarded` rule); post-fix scan returns 0 violations.