### PR TITLE
Add Pillow dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dependencies = [
     "GitPython>=3.1.41", # for logging
     "datasets>=4.0.0",
     "pydantic",
+    "pillow",
     "numpy>=2",  # pinned to avoid incompatibilities
     "hf-xet>=1.1.8",  # pinned to avoid failing test suite
     # Prettiness


### PR DESCRIPTION
# Add Pillow Dependency

## Problem

Running `lighteval accelerate` can fail during task registry initialization with `ModuleNotFoundError: No module named 'PIL'`.

## Root Cause

The built-in MathVista task imports `PIL.Image`, but `Pillow` is not declared in the project dependencies.

## Solution

Add `pillow` to the core project dependencies so built-in task discovery has the package it imports.
