### PR TITLE
Add multilingual task loading to vLLM

### DIFF
--- a/src/lighteval/main_vllm.py
+++ b/src/lighteval/main_vllm.py
@@ -31,6 +31,7 @@ from lighteval.cli_args import (
     dataset_loading_processes,
     job_id,
     load_responses_from_details_date_id,
+    load_tasks_multilingual,
     max_samples,
     model_args,
     num_fewshot_seeds,
@@ -56,6 +57,7 @@ def vllm(
     cot_prompt: Annotated[
         Optional[str], Option(help="Use chain of thought prompt for evaluation.", rich_help_panel=HELP_PANEL_NAME_4)
     ] = None,
+    load_tasks_multilingual: load_tasks_multilingual.type = load_tasks_multilingual.default,
     dataset_loading_processes: dataset_loading_processes.type = dataset_loading_processes.default,
     custom_tasks: custom_tasks.type = custom_tasks.default,
     num_fewshot_seeds: num_fewshot_seeds.type = num_fewshot_seeds.default,
@@ -100,6 +102,7 @@ def vllm(
     pipeline_params = PipelineParameters(
         launcher_type=ParallelismManager.VLLM,
         job_id=job_id,
+        load_tasks_multilingual=load_tasks_multilingual,
         dataset_loading_processes=dataset_loading_processes,
         custom_tasks_directory=custom_tasks,
         num_fewshot_seeds=num_fewshot_seeds,


### PR DESCRIPTION

## Problem

`lighteval vllm` could not run multilingual tasks such as `lexam_mcq_4_idk:en` from the built-in multilingual registry. Other backends already expose `--load-tasks-multilingual`, but the vLLM entrypoint did not, so users had to fall back to `--custom-tasks` or could not resolve the task at all.

## Root Cause

`main_vllm.py` did not import the shared `load_tasks_multilingual` CLI argument and did not pass that value into `PipelineParameters`. As a result, the task registry was always initialized with `load_multilingual=False` for vLLM runs.

## Solution

Add the shared `load_tasks_multilingual` option to the vLLM command and forward it to `PipelineParameters`, matching the behavior of the `accelerate` and `sglang` backends.

## Testing

- Verified that `Registry(tasks="lexam_mcq_4_idk:en|0", load_multilingual=True)` resolves the LEXam task.
- Ran a one-sample vLLM smoke test for `lexam_mcq_4_idk:en|0` with `google/gemma-4-E2B-it` after applying the cluster's cu129 vLLM upgrade recipe; the run completed end-to-end and saved results under `results/gemma4-lexam-mcq4-idk-en-smoke/`.

Made with [Cursor](https://cursor.com)