### PR TITLE
Fix LCB grader failing solutions that read sys.stdin.buffer

### DIFF
--- a/src/lighteval/tasks/tasks/lcb/codegen_metrics.py
+++ b/src/lighteval/tasks/tasks/lcb/codegen_metrics.py
@@ -30,7 +30,7 @@ import zlib
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from decimal import Decimal
 from enum import Enum
-from io import StringIO
+from io import BytesIO, StringIO
 from types import ModuleType
 from typing import Callable, Optional
 
@@ -135,8 +135,13 @@ def call_method(method: Callable, inputs: list | str):
 
     inputs_line_iterator = iter(inputs.split("\n"))
 
+    # Some solutions read from sys.stdin.buffer (binary), which a plain StringIO does not
+    # provide. Expose a binary buffer on the patched stdin, mirroring LiveCodeBench (#1255).
+    mock_stdin = StringIO(inputs)
+    mock_stdin.buffer = BytesIO(inputs.encode())
+
     @patch("builtins.open", mock_open(read_data=inputs))
-    @patch("sys.stdin", StringIO(inputs))
+    @patch("sys.stdin", mock_stdin)
     @patch("sys.stdin.readline", lambda *args: next(inputs_line_iterator))
     @patch("sys.stdin.readlines", lambda *args: inputs.split("\n"))
     @patch("sys.stdin.read", lambda *args: inputs)

--- a/tests/unit/tasks/test_lcb_codegen_metrics.py
+++ b/tests/unit/tasks/test_lcb_codegen_metrics.py
@@ -1,0 +1,41 @@
+# MIT License
+
+# Copyright (c) 2024 The HuggingFace Team
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sys
+
+from lighteval.tasks.tasks.lcb.codegen_metrics import call_method
+
+
+def test_call_method_supports_stdin_buffer():
+    """Regression test for #1255: a solution that reads ``sys.stdin.buffer`` must work.
+
+    The grader patches ``sys.stdin`` with a ``StringIO``, which has no ``buffer`` attribute, so
+    code doing ``sys.stdin.buffer.read()`` previously failed with an ``AttributeError``.
+    """
+    captured = {}
+
+    def method():
+        captured["data"] = sys.stdin.buffer.read()
+
+    call_method(method, "hello world")
+
+    assert captured["data"] == b"hello world"


### PR DESCRIPTION
## What does this PR do?

Fixes #1255.

The LiveCodeBench (LCB) grader's `call_method` patches `sys.stdin` with a `StringIO`:

```python
@patch("sys.stdin", StringIO(inputs))
```

`StringIO` has no `buffer` attribute, so a correct solution that reads binary stdin via `sys.stdin.buffer.read()` raises `AttributeError` and is graded as incorrect.

## Fix

Expose a binary buffer on the patched stdin, mirroring how [LiveCodeBench](https://github.com/LiveCodeBench/LiveCodeBench/blob/main/lcb_runner/evaluation/testing_util.py) does it:

```python
mock_stdin = StringIO(inputs)
mock_stdin.buffer = BytesIO(inputs.encode())
```

## Test

Added `tests/unit/tasks/test_lcb_codegen_metrics.py::test_call_method_supports_stdin_buffer`, which runs a method reading `sys.stdin.buffer.read()` through `call_method` and asserts it receives the encoded inputs. The test fails on `main` (`AttributeError`) and passes with this change.

---
*Disclosure: prepared with AI assistance; reviewed by me and I can explain every line.*