### PR TITLE
Fix reversed gold index in boolq:contrastset prompt

### DIFF
--- a/src/lighteval/tasks/tasks/boolq.py
+++ b/src/lighteval/tasks/tasks/boolq.py
@@ -48,7 +48,7 @@ def boolq_contrastset_prompt(line, task_name: str = None):
             task_name=task_name,
             query=f"{passage}\nQuestion: {question}\nAnswer:",
             choices=["Yes", "No"],
-            gold_index=["No", "Yes"].index(line["answer"]),
+            gold_index=["Yes", "No"].index(line["answer"]),
         )
         for passage, question in zip(line["contrast_inputs"]["passage"], line["contrast_inputs"]["question"])
     ][0]

--- a/tests/unit/tasks/test_boolq.py
+++ b/tests/unit/tasks/test_boolq.py
@@ -1,0 +1,17 @@
+from lighteval.tasks.tasks.boolq import boolq_contrastset_prompt
+
+
+def test_boolq_contrastset_gold_index_matches_answer():
+    # boolq:contrastset derived its gold index from a reversed ["No", "Yes"]
+    # lookup while its choices were ["Yes", "No"], so every sample was graded
+    # against the opposite answer. The gold choice must equal the answer.
+    for answer in ("Yes", "No"):
+        line = {
+            "answer": answer,
+            "contrast_inputs": {
+                "passage": ["A passage."],
+                "question": ["A question?"],
+            },
+        }
+        doc = boolq_contrastset_prompt(line)
+        assert doc.choices[doc.gold_index] == answer


### PR DESCRIPTION
## What

`boolq_contrastset_prompt` (the prompt function for the `boolq:contrastset` task) builds its choices as `["Yes", "No"]` but derives the gold index from a reversed `["No", "Yes"]` lookup:

```python
choices=["Yes", "No"],
gold_index=["No", "Yes"].index(line["answer"]),
```

So the gold index points at the opposite choice: an `answer` of `"Yes"` resolves to `gold_index=1` (`choices[1] == "No"`), and `"No"` resolves to `gold_index=0` (`choices[0] == "Yes"`). Every contrast-set sample is graded against the wrong answer.

## Root cause

The `["No", "Yes"]` lookup table is reversed relative to the function's own `choices`. The sibling `boolq_prompt` and both `record_to_sample` helpers in the same file consistently use the `["Yes", "No"]` order that matches their choices, so this is an isolated typo.

## Fix

Use the same `["Yes", "No"]` lookup so the gold index lines up with `choices`:

```python
gold_index=["Yes", "No"].index(line["answer"]),
```

## Test

Added `tests/unit/tasks/test_boolq.py` asserting `doc.choices[doc.gold_index] == answer` for both `"Yes"` and `"No"`. It fails before the change (gold resolves to the opposite choice) and passes after.