### PR TITLE
Fix asdiv prompt truncating multi-character gold answers

### DIFF
--- a/src/lighteval/tasks/tasks/asdiv.py
+++ b/src/lighteval/tasks/tasks/asdiv.py
@@ -31,7 +31,7 @@ def asdiv_prompt(line, task_name: str = None):
     return Doc(
         task_name=task_name,
         query=f"{line['body']}\nQuestion:{line['question']}\nAnswer:",
-        choices=line["answer"].split(" (")[0],
+        choices=[line["answer"].split(" (")[0]],
         gold_index=[0],
     )
 

--- a/tests/unit/tasks/test_asdiv.py
+++ b/tests/unit/tasks/test_asdiv.py
@@ -1,0 +1,15 @@
+from lighteval.tasks.tasks.asdiv import asdiv_prompt
+
+
+def test_asdiv_prompt_keeps_full_gold_answer():
+    # asdiv stored choices as a bare string, so Doc.get_golds() indexed the
+    # string and truncated a multi-character answer to its first character
+    # (e.g. "35" -> "3"). choices must be a list so the gold answer survives.
+    line = {
+        "body": "There are some apples.",
+        "question": "How many apples are there?",
+        "answer": "35 (apples)",
+    }
+    doc = asdiv_prompt(line)
+    assert doc.choices == ["35"]
+    assert doc.get_golds() == ["35"]


### PR DESCRIPTION
### Problem

`asdiv_prompt` sets `choices` to a bare string instead of a list:

```python
def asdiv_prompt(line, task_name: str = None):
    return Doc(
        task_name=task_name,
        query=f"{line['body']}\nQuestion:{line['question']}\nAnswer:",
        choices=line["answer"].split(" (")[0],   # bare string, e.g. "35"
        gold_index=[0],
    )
```

`Doc.choices` is a `list[str]`, and `Doc.get_golds()` indexes it with the gold index:

```python
for gold_ix in as_list(self.gold_index):
    golds.extend(as_list(self.choices[gold_ix]))
```

When `choices` is the string `"35"`, `choices[0]` indexes the string and yields `"3"`, so the gold answer is silently truncated to its first character. ASDiv answers have the form `"<value> (<unit>)"` (which is why the `.split(" (")[0]` is there), so the extracted value is usually multi-character:

```
answer "35 (apples)" -> gold ["3"]   (should be ["35"])
answer "128"         -> gold ["1"]   (should be ["128"])
answer "3.5 (m)"     -> gold ["3"]   (should be ["3.5"])
```

`get_golds()` feeds the reference into the task's `exact_match` metric, so a model that correctly outputs `35` is scored against gold `3` and marked wrong. Every sibling generative task wraps the value in a list (`unscramble`, `numeracy`, `arithmetic`, ...); `asdiv` is the only one missing the brackets.

### Fix

Wrap the extracted answer in a list, matching the sibling tasks and the `Doc.choices: list[str]` contract:

```python
choices=[line["answer"].split(" (")[0]],
```

### Test

Adds `tests/unit/tasks/test_asdiv.py`, which calls `asdiv_prompt` on a multi-character answer and asserts `doc.choices == ["35"]` and `doc.get_golds() == ["35"]`. It fails before (`get_golds()` returns `["3"]`) and passes after.
