### PR TITLE
Fix always-true conditional that made DEFAULT_FORMAT unreachable

### DIFF
--- a/src/lighteval/metrics/utils/llm_as_judge.py
+++ b/src/lighteval/metrics/utils/llm_as_judge.py
@@ -134,7 +134,7 @@ class JudgeLM:
         self.hf_provider = hf_provider
         self.max_tokens = max_tokens
 
-        self.response_format = response_format if not None else DEFAULT_FORMAT
+        self.response_format = response_format if response_format is not None else DEFAULT_FORMAT
 
         self.backend_options = backend_options or {}
 

--- a/tests/unit/metrics/test_llm_as_judge_response_format.py
+++ b/tests/unit/metrics/test_llm_as_judge_response_format.py
@@ -1,0 +1,50 @@
+# MIT License
+
+# Copyright (c) 2024 The HuggingFace Team
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from pydantic import BaseModel
+
+from lighteval.metrics.utils.llm_as_judge import DEFAULT_FORMAT, JudgeLM
+
+
+class Verdict(BaseModel):
+    score: int
+
+
+def _make_judge(**kwargs):
+    return JudgeLM(
+        model="openai/dummy-model",
+        templates=lambda question, answer, options=None, gold=None, **kw: [{"role": "user", "content": question}],
+        process_judge_response=lambda response: response,
+        judge_backend="litellm",
+        **kwargs,
+    )
+
+
+def test_response_format_falls_back_to_default():
+    """A judge built without an explicit `response_format` gets `DEFAULT_FORMAT`."""
+    assert _make_judge().response_format == DEFAULT_FORMAT
+
+
+def test_explicit_response_format_is_kept():
+    """An explicit `response_format` is never overwritten by the default."""
+    assert _make_judge(response_format={"type": "json_object"}).response_format == {"type": "json_object"}
+    assert _make_judge(response_format=Verdict).response_format is Verdict


### PR DESCRIPTION
## What this fixes

`JudgeLM.__init__` sets the response format like this:

```python
self.response_format = response_format if not None else DEFAULT_FORMAT
```

`not None` is the constant `True`, so the condition never looks at `response_format` at all and the `else` branch can never run. Two consequences:

1. `DEFAULT_FORMAT = {"type": "text"}` is unreachable dead code.
2. A judge constructed without an explicit `response_format` keeps `None`, not the `{"type": "text"}` the constant was added to provide.

On `main`:

```python
>>> judge = JudgeLM(model=..., templates=..., process_judge_response=..., judge_backend="litellm")
>>> judge.response_format
None                     # DEFAULT_FORMAT is {'type': 'text'}
```

`self.response_format` is then handed straight to the backends — into the litellm kwargs, and as `response_format=` on both `client.beta.chat.completions.parse(...)` and `client.chat.completions.create(...)` for the openai/tgi path.

I found this while working on #1296 in the same file; it is not from the issue tracker.

## The change

```diff
-        self.response_format = response_format if not None else DEFAULT_FORMAT
+        self.response_format = response_format if response_format is not None else DEFAULT_FORMAT
```

## On the behaviour change

This does change what the default judge sends: `None` becomes `{"type": "text"}`. I believe that is safe, because `{"type": "text"}` *is* the OpenAI-compatible default response format, so sending it explicitly is equivalent to omitting it for a compliant server. Explicitly-passed values (dict or pydantic model) are unaffected — they were already being kept, just for the wrong reason.

If you would rather not change what goes over the wire, the alternative is to drop `DEFAULT_FORMAT` and assign `response_format` directly, which makes the code state what it actually does today. I went with restoring the evident intent, but I am happy to switch to that instead — your call.

## Tests

Added `tests/unit/metrics/test_llm_as_judge_response_format.py`:

- `test_response_format_falls_back_to_default` — no explicit format yields `DEFAULT_FORMAT`
- `test_explicit_response_format_is_kept` — an explicit dict and an explicit pydantic model both survive untouched

The first fails on `main` and passes with the fix; the second passes either way, pinning that the fallback does not stomp explicit values:

```
# before
FAILED ...::test_response_format_falls_back_to_default
1 failed, 1 passed

# after
2 passed
```

`ruff format` and `ruff check` are clean on both files.
