### PR TITLE
Add add_generation_prompt=True when tokenizing judge prompts

### DIFF
--- a/src/lighteval/metrics/utils/llm_as_judge.py
+++ b/src/lighteval/metrics/utils/llm_as_judge.py
@@ -301,7 +301,7 @@ class JudgeLM:
         return response
 
     def __call_vllm(self, prompt):
-        tokenized = [self.tokenizer.apply_chat_template(p) for p in prompt]
+        tokenized = [self.tokenizer.apply_chat_template(p, add_generation_prompt=True) for p in prompt]
         # Convert token IDs to TokensPrompt format for vLLM v0.15+
         prompts = [{"prompt_token_ids": token_ids} for token_ids in tokenized]
         output = self.pipe.generate(prompts=prompts, sampling_params=self.sampling_params, use_tqdm=True)


### PR DESCRIPTION
Fixes #1346

## Problem

`JudgeLM.__call_vllm` renders judge prompts with `apply_chat_template(p)` and no `add_generation_prompt`. The rendered text therefore ends at the close of the user turn (for example `...<|im_end|>\n`) and never opens the assistant turn, so the model has to infer that a reply is what comes next.

Most of the time it does. Intermittently it instead continues the conversation by starting a fresh user turn, and the resulting text does not parse into a score. The reporter saw this with Qwen2.5-7B-Instruct as the judge.

## Change

Pass `add_generation_prompt=True` when tokenizing.

This matches how the rest of the codebase renders chat prompts. Both other `apply_chat_template` call sites in `src/` already pass it:

- `src/lighteval/tasks/prompt_manager.py:82`
- `src/lighteval/tasks/prompt_manager.py:132`

`src/lighteval/metrics/utils/llm_as_judge.py:304` was the only call site that did not, so this brings the judge in line with the existing convention rather than introducing a new one.

## Testing

I was not able to exercise the vLLM judge path locally, since it needs a vLLM runtime and a GPU that I do not have. What I did check:

- `python -m py_compile src/lighteval/metrics/utils/llm_as_judge.py` passes.
- Reviewed every `apply_chat_template` call site in `src/` to confirm the argument is consistent with the two in `prompt_manager.py` and that no other call site was missed.

A maintainer with a vLLM setup may want to confirm against a judge model before merging.

AI assistance was used for this change.
