### PR TITLE
Parse hellaswag_arabic endings with ast.literal_eval

### DIFF
--- a/src/lighteval/tasks/multilingual/tasks/arabic.py
+++ b/src/lighteval/tasks/multilingual/tasks/arabic.py
@@ -17,6 +17,7 @@ knowledge, multilingual, multiple-choice
 paper:
 """
 
+import ast
 import random
 import re
 from string import ascii_uppercase
@@ -600,7 +601,7 @@ copa_ext_ar_task = LightevalTaskConfig(
 def hellaswag_arabic_pfn(line, task_name: str = None):
     ctx = re.sub(r"\[.*?\]", "", line["ctx"])  # Remove latin words within brackets
     endings = [
-        re.sub(r"\[.*?\]", "", e) for e in eval(line["endings"])
+        re.sub(r"\[.*?\]", "", e) for e in ast.literal_eval(line["endings"])
     ]  # endings is a string representation of a list
     answer_index = line["label"]
     instruction = "بناء على السياق التالي، اختر النهاية الصحيحة من الاقتراحات التالية"


### PR DESCRIPTION
Fixes #1293

## Problem

`hellaswag_arabic_pfn` parses the `endings` field with the builtin `eval()`:

```python
endings = [
    re.sub(r"\[.*?\]", "", e) for e in eval(line["endings"])
]  # endings is a string representation of a list
```

The field holds a string representation of a list, but `eval()` executes arbitrary Python rather than just parsing a literal. The value comes from `OALL/AlGhafa-Arabic-LLM-Benchmark-Translated`, a community-hosted dataset on the Hub, so a crafted `endings` value in that dataset or any later revision of it would run code on whichever machine is running the evaluation.

## Change

Use `ast.literal_eval`, which accepts the same literal syntax but evaluates only literals, and add the `ast` import.

## Testing

`python -m py_compile src/lighteval/tasks/multilingual/tasks/arabic.py` passes.

Checked that the parsing behaviour is unchanged for real inputs and that the injection no longer executes:

```
legit    -> ['ending ', 'ending two', 'ending three']
arabic   -> ['النهاية', 'الثانية']
dq quote -> ['a', 'b']
malicious ("__import__('os').system(...)") -> blocked: ValueError
malicious ("eval('1+1')")                  -> blocked: ValueError
```

Single and double quoted lists, and non-ASCII contents, all parse identically to before. `main_inspect.py:568` also calls `eval(...)`, but that is `inspect_ai`'s own `eval` function rather than the builtin, so it is unrelated and left alone.

AI assistance was used for this change.
